### PR TITLE
Fixing README config Table Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ Field | Environmental Variable | Default | Description | Example
 `resultJson` |  `JEST_STARE_RESULT_JSON` | `jest-results.json` | indicate the raw JSON results file name | `"resultJson": "data.json"`
 `resultHtml` |  `JEST_STARE_RESULT_HTML` | `index.html` | indicate the main html file name | `"resultHtml": "main.html"`
 `log` |  `JEST_STARE_LOG` | `true` | specify whether or not jest-stare should log to the console | `"log": "false"`
-<!-- `merge` |  `JEST_STARE_MERGE` | `false` | merge new results in instead of overwriting results (experimental) | `"merge": "true"` -->
 `jestStareConfigJson` |  `JEST_STARE_CONFIG_JSON` |  `undefined` | request to save jest-stare config raw JSON results in the file name | `"jestStareConfigJson": "jest-stare-config.json"`
 `coverageLink` |  `JEST_STARE_COVERAGE_LINK` | `undefined` | link to coverage report if available | `"coverageLink": "../../coverage/lcov-report/index.html"`
 `additionalResultsProcessors` |  `JEST_STARE_ADDITIONAL_RESULTS_PROCESSORS` | `undefined` | add additional test result processors to produce multiple report |`"additionalResultsProcessors": ["jest-html-reporter", "jest-junit"]`
+<!-- `merge` |  `JEST_STARE_MERGE` | `false` | merge new results in instead of overwriting results (experimental) | `"merge": "true"` -->
 
 ### API
 You can programmatically invoke jest-stare and provide jest response data via:


### PR DESCRIPTION
Commented line in the middle of table broke the layout