### PR TITLE
Fix CLI argument processing

### DIFF
--- a/src/jest-stare.ts
+++ b/src/jest-stare.ts
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 import { CLI } from "./cli/CLI";
 
-CLI.run(process.argv);
+CLI.run(process.argv.slice(2));


### PR DESCRIPTION
My previous PR #166 didn't account for how node commands pass in arguments; this caused the following error `SyntaxError: Unexpected token � in JSON at position 0`

This PR fixes that.