### PR TITLE
Create Collapsible Boxes

### DIFF
--- a/__tests__/__integration__/render/suites/__snapshots__/TestSuite.test.ts.snap
+++ b/__tests__/__integration__/render/suites/__snapshots__/TestSuite.test.ts.snap
@@ -2072,40 +2072,2501 @@ Array [
 exports[`TestSuite tests should create proper elements for nested describes with reused names 1`] = `
 Array [
   <div
-    class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-    id="C:\\\\Users\\\\KELDA16\\\\Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\__examples__\\\\NestedDescribeTests.example.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card failed-test.passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\NestedDescribeTests.example.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-      id="outer 0"
+      class="card-header"
+      id="C__Users_KELDA16_Work_Dev_node_jest-stare___tests_____examples___NestedDescribeTests_example_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        outer 0
-      </h6>
-      <div
-        class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-        id="outer 0.outer 1"
-      >
-        <h6
-          class="border-bottom pb-2 mb-0 display-6"
+        <button
+          class="btn btn-block"
+          data-target="#C__Users_KELDA16_Work_Dev_node_jest-stare___tests_____examples___NestedDescribeTests_example_ts_detail"
+          data-toggle="collapse"
         >
-          outer 1
-        </h6>
+          C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\NestedDescribeTests.example.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              7
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="C__Users_KELDA16_Work_Dev_node_jest-stare___tests_____examples___NestedDescribeTests_example_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
         <div
           class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-          id="outer 0.outer 1.outer 2"
+          id="outer 0"
         >
           <h6
             class="border-bottom pb-2 mb-0 display-6"
           >
-            outer 2
+            outer 0
+          </h6>
+          <div
+            class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+            id="outer 0.outer 1"
+          >
+            <h6
+              class="border-bottom pb-2 mb-0 display-6"
+            >
+              outer 1
+            </h6>
+            <div
+              class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+              id="outer 0.outer 1.outer 2"
+            >
+              <h6
+                class="border-bottom pb-2 mb-0 display-6"
+              >
+                outer 2
+              </h6>
+              <div
+                class="media text-muted pt-3 passed-test"
+                id="should-pass"
+              >
+                <img
+                  alt=""
+                  class="mr-2 rounded"
+                  data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+                />
+                <div
+                  class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                >
+                  <div
+                    class="d-flex justify-content-between align-items-center w-100"
+                  >
+                    <strong
+                      class="text-gray-dark"
+                    >
+                      should pass
+                    </strong>
+                    <small
+                      class="d-block text-right mt-3"
+                    >
+                      0.002s
+                    </small>
+                  </div>
+                  <span
+                    class="d-block mb-2"
+                  >
+                    passed
+                  </span>
+                </div>
+              </div>
+              <div
+                class="my-3 p-3 bg-white rounded box-shadow passed-test"
+                id="outer 0.outer 1.outer 2.first outer 3"
+              >
+                <h6
+                  class="border-bottom pb-2 mb-0 display-6"
+                >
+                  first outer 3
+                </h6>
+                <div
+                  class="my-3 p-3 bg-white rounded box-shadow passed-test"
+                  id="outer 0.outer 1.outer 2.first outer 3.outer 4"
+                >
+                  <h6
+                    class="border-bottom pb-2 mb-0 display-6"
+                  >
+                    outer 4
+                  </h6>
+                  <div
+                    class="media text-muted pt-3 passed-test"
+                    id="should-pass"
+                  >
+                    <img
+                      alt=""
+                      class="mr-2 rounded"
+                      data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+                    />
+                    <div
+                      class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                    >
+                      <div
+                        class="d-flex justify-content-between align-items-center w-100"
+                      >
+                        <strong
+                          class="text-gray-dark"
+                        >
+                          should pass
+                        </strong>
+                        <small
+                          class="d-block text-right mt-3"
+                        >
+                          0s
+                        </small>
+                      </div>
+                      <span
+                        class="d-block mb-2"
+                      >
+                        passed
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+                id="outer 0.outer 1.outer 2.outer 3"
+              >
+                <h6
+                  class="border-bottom pb-2 mb-0 display-6"
+                >
+                  outer 3
+                </h6>
+                <div
+                  class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+                  id="outer 0.outer 1.outer 2.outer 3.outer 4"
+                >
+                  <h6
+                    class="border-bottom pb-2 mb-0 display-6"
+                  >
+                    outer 4
+                  </h6>
+                  <div
+                    class="media text-muted pt-3 passed-test"
+                    id="should-pass"
+                  >
+                    <img
+                      alt=""
+                      class="mr-2 rounded"
+                      data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+                    />
+                    <div
+                      class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                    >
+                      <div
+                        class="d-flex justify-content-between align-items-center w-100"
+                      >
+                        <strong
+                          class="text-gray-dark"
+                        >
+                          should pass
+                        </strong>
+                        <small
+                          class="d-block text-right mt-3"
+                        >
+                          0s
+                        </small>
+                      </div>
+                      <span
+                        class="d-block mb-2"
+                      >
+                        passed
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="media text-muted pt-3 failed-test"
+                    id="should-fail"
+                  >
+                    <img
+                      alt=""
+                      class="mr-2 rounded"
+                      data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
+                    />
+                    <div
+                      class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                    >
+                      <div
+                        class="d-flex justify-content-between align-items-center w-100"
+                      >
+                        <strong
+                          class="text-gray-dark"
+                        >
+                          should fail
+                        </strong>
+                        <small
+                          class="d-block text-right mt-3"
+                        >
+                          0.11s
+                        </small>
+                      </div>
+                      <span
+                        class="d-block mb-2"
+                      >
+                        failed
+                      </span>
+                      <div
+                        class="d-flex justify-content-between align-items-center w-100"
+                      >
+                        <div />
+                        <button
+                          aria-controls="should-fail-diff"
+                          aria-expanded="false"
+                          class="btn btn-light btn-sm"
+                          data-target="#should-fail-diff"
+                          data-toggle="collapse"
+                          type="button"
+                        >
+                          raw
+                        </button>
+                      </div>
+                      <pre
+                        class="collapse show"
+                        id="should-fail-diff"
+                      >
+                        <code>
+                          <div>
+                            <span>
+                              Error: expect(received).toBe(expected) // Object.is equality
+                            </span>
+                          </div>
+                          <div>
+                            <span />
+                          </div>
+                          <div>
+                            <span>
+                              Expected value to be:
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                false
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                              Received:
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                true
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at Object.it (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\NestedDescribeTests.example.ts:20:38)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at Object.asyncFn (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at resolve (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at new Promise (&lt;anonymous&gt;)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at mapper (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at promise.then (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at &lt;anonymous&gt;
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at process._tickCallback (internal/process/next_tick.js:188:7)
+                            </span>
+                          </div>
+                        </code>
+                      </pre>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+                id="outer 0.outer 1.outer 2.next outer 3"
+              >
+                <h6
+                  class="border-bottom pb-2 mb-0 display-6"
+                >
+                  next outer 3
+                </h6>
+                <div
+                  class="media text-muted pt-3 passed-test"
+                  id="should-be-around"
+                >
+                  <img
+                    alt=""
+                    class="mr-2 rounded"
+                    data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+                  />
+                  <div
+                    class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                  >
+                    <div
+                      class="d-flex justify-content-between align-items-center w-100"
+                    >
+                      <strong
+                        class="text-gray-dark"
+                      >
+                        should be around
+                      </strong>
+                      <small
+                        class="d-block text-right mt-3"
+                      >
+                        0s
+                      </small>
+                    </div>
+                    <span
+                      class="d-block mb-2"
+                    >
+                      passed
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+                  id="outer 0.outer 1.outer 2.next outer 3.outer 4"
+                >
+                  <h6
+                    class="border-bottom pb-2 mb-0 display-6"
+                  >
+                    outer 4
+                  </h6>
+                  <div
+                    class="media text-muted pt-3 passed-test"
+                    id="should-pass"
+                  >
+                    <img
+                      alt=""
+                      class="mr-2 rounded"
+                      data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+                    />
+                    <div
+                      class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                    >
+                      <div
+                        class="d-flex justify-content-between align-items-center w-100"
+                      >
+                        <strong
+                          class="text-gray-dark"
+                        >
+                          should pass
+                        </strong>
+                        <small
+                          class="d-block text-right mt-3"
+                        >
+                          0s
+                        </small>
+                      </div>
+                      <span
+                        class="d-block mb-2"
+                      >
+                        passed
+                      </span>
+                    </div>
+                  </div>
+                  <div
+                    class="media text-muted pt-3 failed-test"
+                    id="should-fail"
+                  >
+                    <img
+                      alt=""
+                      class="mr-2 rounded"
+                      data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
+                    />
+                    <div
+                      class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                    >
+                      <div
+                        class="d-flex justify-content-between align-items-center w-100"
+                      >
+                        <strong
+                          class="text-gray-dark"
+                        >
+                          should fail
+                        </strong>
+                        <small
+                          class="d-block text-right mt-3"
+                        >
+                          0s
+                        </small>
+                      </div>
+                      <span
+                        class="d-block mb-2"
+                      >
+                        failed
+                      </span>
+                      <div
+                        class="d-flex justify-content-between align-items-center w-100"
+                      >
+                        <div />
+                        <button
+                          aria-controls="should-fail-diff"
+                          aria-expanded="false"
+                          class="btn btn-light btn-sm"
+                          data-target="#should-fail-diff"
+                          data-toggle="collapse"
+                          type="button"
+                        >
+                          raw
+                        </button>
+                      </div>
+                      <pre
+                        class="collapse show"
+                        id="should-fail-diff"
+                      >
+                        <code>
+                          <div>
+                            <span>
+                              Error: expect(received).toBe(expected) // Object.is equality
+                            </span>
+                          </div>
+                          <div>
+                            <span />
+                          </div>
+                          <div>
+                            <span>
+                              Expected value to be:
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                false
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                              Received:
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                true
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at Object.it (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\NestedDescribeTests.example.ts:33:38)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at Object.asyncFn (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at resolve (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at new Promise (&lt;anonymous&gt;)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at mapper (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at promise.then (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at &lt;anonymous&gt;
+                            </span>
+                          </div>
+                          <div>
+                            <span>
+                                  at process._tickCallback (internal/process/next_tick.js:188:7)
+                            </span>
+                          </div>
+                        </code>
+                      </pre>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="media text-muted pt-3 passed-test"
+                  id="should-be-around-too"
+                >
+                  <img
+                    alt=""
+                    class="mr-2 rounded"
+                    data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+                  />
+                  <div
+                    class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                  >
+                    <div
+                      class="d-flex justify-content-between align-items-center w-100"
+                    >
+                      <strong
+                        class="text-gray-dark"
+                      >
+                        should be around too
+                      </strong>
+                      <small
+                        class="d-block text-right mt-3"
+                      >
+                        0s
+                      </small>
+                    </div>
+                    <span
+                      class="d-block mb-2"
+                    >
+                      passed
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="my-3 p-3 bg-white rounded box-shadow passed-test"
+                id="outer 0.outer 1.outer 2.last outer 3"
+              >
+                <h6
+                  class="border-bottom pb-2 mb-0 display-6"
+                >
+                  last outer 3
+                </h6>
+                <div
+                  class="my-3 p-3 bg-white rounded box-shadow passed-test"
+                  id="outer 0.outer 1.outer 2.last outer 3.outer 4"
+                >
+                  <h6
+                    class="border-bottom pb-2 mb-0 display-6"
+                  >
+                    outer 4
+                  </h6>
+                  <div
+                    class="media text-muted pt-3 passed-test"
+                    id="should-pass"
+                  >
+                    <img
+                      alt=""
+                      class="mr-2 rounded"
+                      data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+                    />
+                    <div
+                      class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                    >
+                      <div
+                        class="d-flex justify-content-between align-items-center w-100"
+                      >
+                        <strong
+                          class="text-gray-dark"
+                        >
+                          should pass
+                        </strong>
+                        <small
+                          class="d-block text-right mt-3"
+                        >
+                          0s
+                        </small>
+                      </div>
+                      <span
+                        class="d-block mb-2"
+                      >
+                        passed
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`TestSuite tests should create proper elements for passing and failing image snapshots 1`] = `
+Array [
+  <div
+    class="my-3 p-3 bg-white rounded box-shadow card failed-test.passed-test"
+  >
+    <div
+      class="card-header"
+      id="_tmp_jest-stare___tests_____examples___foo_ts_header"
+    >
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
+      >
+        <button
+          class="btn btn-block"
+          data-target="#_tmp_jest-stare___tests_____examples___foo_ts_detail"
+          data-toggle="collapse"
+        >
+          /tmp/jest-stare/__tests__/__examples__/foo.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="_tmp_jest-stare___tests_____examples___foo_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+          id="image snapshot test"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            image snapshot test
+          </h6>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-pass-with-image-snapshot"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should pass with image snapshot
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.109s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 failed-test"
+            id="should-fail-with-image-snapshot"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should fail with image snapshot
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.213s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                failed
+              </span>
+              <div
+                class="image-snapshot-diff"
+              >
+                <span
+                  class="text-muted"
+                >
+                  Expected image to match or be a close match to snapshot but was 10.4736328125% different from snapshot (429 differing pixels).
+                </span>
+                <a
+                  href="image_snapshot_diff/foo-ts-image-snapshot-test-should-fail-with-image-snapshot-1-diff.png"
+                >
+                  <img
+                    src="image_snapshot_diff/foo-ts-image-snapshot-test-should-fail-with-image-snapshot-1-diff.png"
+                  />
+                </a>
+              </div>
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <div />
+                <button
+                  aria-controls="should-fail-with-image-snapshot-diff"
+                  aria-expanded="false"
+                  class="btn btn-light btn-sm"
+                  data-target="#should-fail-with-image-snapshot-diff"
+                  data-toggle="collapse"
+                  type="button"
+                >
+                  raw
+                </button>
+              </div>
+              <pre
+                class="collapse"
+                id="should-fail-with-image-snapshot-diff"
+              >
+                <code>
+                  <div>
+                    <span>
+                      Error: Expected image to match or be a close match to snapshot but was 10.4736328125% different from snapshot (429 differing pixels).
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                      See diff for details: /tmp/jest-stare/__tests__/__examples__/__image_snapshots__/__diff_output__/foo-ts-image-snapshot-test-should-fail-with-image-snapshot-1-diff.png
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.it (/tmp/jest-stare/__tests__/__examples__/foo.ts:17:29)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.asyncFn (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/jasmine_async.js:82:37)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at resolve (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:52:12)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at new Promise (&lt;anonymous&gt;)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at mapper (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:39:19)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at promise.then (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:73:82)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at &lt;anonymous&gt;
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at process._tickCallback (internal/process/next_tick.js:188:7)
+                    </span>
+                  </div>
+                </code>
+              </pre>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 failed-test"
+            id="should-fail-with-another-image-snapshot"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should fail with another image snapshot
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.213s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                failed
+              </span>
+              <div
+                class="image-snapshot-diff"
+              >
+                <span
+                  class="text-muted"
+                >
+                  Expected image to match or be a close match to snapshot but was 10.4736328125% different from snapshot (429 differing pixels).
+                </span>
+                <a
+                  href="image_snapshot_diff/foo-ts-image-snapshot-test-should-fail-with-another-image-snapshot-1-diff.png"
+                >
+                  <img
+                    src="image_snapshot_diff/foo-ts-image-snapshot-test-should-fail-with-another-image-snapshot-1-diff.png"
+                  />
+                </a>
+              </div>
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <div />
+                <button
+                  aria-controls="should-fail-with-another-image-snapshot-diff"
+                  aria-expanded="false"
+                  class="btn btn-light btn-sm"
+                  data-target="#should-fail-with-another-image-snapshot-diff"
+                  data-toggle="collapse"
+                  type="button"
+                >
+                  raw
+                </button>
+              </div>
+              <pre
+                class="collapse"
+                id="should-fail-with-another-image-snapshot-diff"
+              >
+                <code>
+                  <div>
+                    <span>
+                      Error: Expected image to match or be a close match to snapshot but was 10.4736328125% different from snapshot (429 differing pixels).
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                      See diff for details: /tmp/jest-stare/__tests__/__examples__/__image_snapshots__/__diff_output__/foo-ts-image-snapshot-test-should-fail-with-another-image-snapshot-1-diff.png
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.it (/tmp/jest-stare/__tests__/__examples__/foo.ts:17:29)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.asyncFn (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/jasmine_async.js:82:37)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at resolve (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:52:12)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at new Promise (&lt;anonymous&gt;)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at mapper (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:39:19)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at promise.then (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:73:82)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at &lt;anonymous&gt;
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at process._tickCallback (internal/process/next_tick.js:188:7)
+                    </span>
+                  </div>
+                </code>
+              </pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`TestSuite tests should create proper elements for pending tests 1`] = `
+Array [
+  <div
+    class="my-3 p-3 bg-white rounded box-shadow card failed-test.passed-test.pending-test"
+  >
+    <div
+      class="card-header"
+      id="C__Users_KELDA16_Work_Dev_node_jest-stare___tests_____examples___PendingTests_example_ts_header"
+    >
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
+      >
+        <button
+          class="btn btn-block"
+          data-target="#C__Users_KELDA16_Work_Dev_node_jest-stare___tests_____examples___PendingTests_example_ts_detail"
+          data-toggle="collapse"
+        >
+          C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\PendingTests.example.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              1
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="C__Users_KELDA16_Work_Dev_node_jest-stare___tests_____examples___PendingTests_example_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test.pending-test"
+          id="pending tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            pending tests
+          </h6>
+          <div
+            class="media text-muted pt-3 pending-test"
+            id="should-pend"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=ffc107&fg=ffc107&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should pend
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                pending
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-pass"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should pass
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 failed-test"
+            id="should-fail"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should fail
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.09s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                failed
+              </span>
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <div />
+                <button
+                  aria-controls="should-fail-diff"
+                  aria-expanded="false"
+                  class="btn btn-light btn-sm"
+                  data-target="#should-fail-diff"
+                  data-toggle="collapse"
+                  type="button"
+                >
+                  raw
+                </button>
+              </div>
+              <pre
+                class="collapse show"
+                id="should-fail-diff"
+              >
+                <code>
+                  <div>
+                    <span>
+                      Error: Failure here
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.it (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\PendingTests.example.ts:9:15)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.asyncFn (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at resolve (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at new Promise (&lt;anonymous&gt;)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at mapper (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at promise.then (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at &lt;anonymous&gt;
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at process._tickCallback (internal/process/next_tick.js:188:7)
+                    </span>
+                  </div>
+                </code>
+              </pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`TestSuite tests should create proper elements for simple failing tests 1`] = `
+Array [
+  <div
+    class="my-3 p-3 bg-white rounded box-shadow card failed-test.passed-test"
+  >
+    <div
+      class="card-header"
+      id="Work_Dev_node_jest-stare___tests___utils_IO_test_ts_header"
+    >
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
+      >
+        <button
+          class="btn btn-block"
+          data-target="#Work_Dev_node_jest-stare___tests___utils_IO_test_ts_detail"
+          data-toggle="collapse"
+        >
+          Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="Work_Dev_node_jest-stare___tests___utils_IO_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+          id="IO tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            IO tests
+          </h6>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-pretend-to-write-to-a-file"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should pretend to write to a file
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.003s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-match-snapshot-with-one-field"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should match snapshot with one field
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.003s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 failed-test"
+            id="should-match-snapshot-with-two-fields"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should match snapshot with two fields
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.14s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                failed
+              </span>
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <div />
+                <button
+                  aria-controls="should-match-snapshot-with-two-fields-diff"
+                  aria-expanded="false"
+                  class="btn btn-light btn-sm"
+                  data-target="#should-match-snapshot-with-two-fields-diff"
+                  data-toggle="collapse"
+                  type="button"
+                >
+                  raw
+                </button>
+              </div>
+              <pre
+                class="collapse show"
+                id="should-match-snapshot-with-two-fields-diff"
+              >
+                <code>
+                  <div>
+                    <span>
+                      Error: expect(value).toMatchSnapshot()
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span>
+                      Received value does not match stored snapshot 1.
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span
+                      style="color:#dc3545"
+                    >
+                      - Snapshot
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#28a745"
+                    >
+                      + Received
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span>
+                        Object {
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          "name": "someone",
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#28a745"
+                    >
+                      +   "newThing": "here",
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          "password": "secret",
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                        }
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.it (Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts:40:22)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.asyncFn (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at resolve (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at new Promise (&lt;anonymous&gt;)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at mapper (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at promise.then (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at &lt;anonymous&gt;
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at process._tickCallback (internal/process/next_tick.js:188:7)
+                    </span>
+                  </div>
+                </code>
+              </pre>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 failed-test"
+            id="should-match-snapshot-with-three-fields"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should match snapshot with three fields
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.001s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                failed
+              </span>
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <div />
+                <button
+                  aria-controls="should-match-snapshot-with-three-fields-diff"
+                  aria-expanded="false"
+                  class="btn btn-light btn-sm"
+                  data-target="#should-match-snapshot-with-three-fields-diff"
+                  data-toggle="collapse"
+                  type="button"
+                >
+                  raw
+                </button>
+              </div>
+              <pre
+                class="collapse show"
+                id="should-match-snapshot-with-three-fields-diff"
+              >
+                <code>
+                  <div>
+                    <span>
+                      Error: expect(value).toMatchSnapshot()
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span>
+                      Received value does not match stored snapshot 1.
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span
+                      style="color:#dc3545"
+                    >
+                      - Snapshot
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#28a745"
+                    >
+                      + Received
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span>
+                        Object {
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#dc3545"
+                    >
+                      -   "data": "sample",
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          "name": "someone",
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          "password": "secret",
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                        }
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.it (Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts:48:22)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.asyncFn (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at resolve (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at new Promise (&lt;anonymous&gt;)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at mapper (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at promise.then (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at &lt;anonymous&gt;
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at process._tickCallback (internal/process/next_tick.js:188:7)
+                    </span>
+                  </div>
+                </code>
+              </pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
+  >
+    <div
+      class="card-header"
+      id="Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_header"
+    >
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
+      >
+        <button
+          class="btn btn-block"
+          data-target="#Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_detail"
+          data-toggle="collapse"
+        >
+          Work\\Dev\\node\\jest-stare\\__tests__\\reporter\\Reporter.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Reporter tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Reporter tests
+          </h6>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-instantiate-reporter-class"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should instantiate Reporter class
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.001s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`TestSuite tests should create proper elements for simple passing tests 1`] = `
+Array [
+  <div
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
+  >
+    <div
+      class="card-header"
+      id="Work_Dev_node_jest-stare___tests___utils_IO_test_ts_header"
+    >
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
+      >
+        <button
+          class="btn btn-block"
+          data-target="#Work_Dev_node_jest-stare___tests___utils_IO_test_ts_detail"
+          data-toggle="collapse"
+        >
+          Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              4
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="Work_Dev_node_jest-stare___tests___utils_IO_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="IO tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            IO tests
+          </h6>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-pretend-to-write-to-a-file"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should pretend to write to a file
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.003s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-match-snapshot-with-one-field"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should match snapshot with one field
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.001s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-match-snapshot-with-two-fields"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should match snapshot with two fields
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.001s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-match-snapshot-with-three-fields"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should match snapshot with three fields
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
+  >
+    <div
+      class="card-header"
+      id="Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_header"
+    >
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
+      >
+        <button
+          class="btn btn-block"
+          data-target="#Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_detail"
+          data-toggle="collapse"
+        >
+          Work\\Dev\\node\\jest-stare\\__tests__\\reporter\\Reporter.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Reporter tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Reporter tests
+          </h6>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-instantiate-reporter-class"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should instantiate Reporter class
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.001s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;
+
+exports[`TestSuite tests should create proper elements for two diffs in html 1`] = `
+Array [
+  <div
+    class="my-3 p-3 bg-white rounded box-shadow card failed-test.passed-test"
+  >
+    <div
+      class="card-header"
+      id="jest-stare___tests___example_FailingTests_test_ts_header"
+    >
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
+      >
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___example_FailingTests_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\example\\FailingTests.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___example_FailingTests_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+          id="Failing Tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Failing Tests
+          </h6>
+          <div
+            class="media text-muted pt-3 failed-test"
+            id="should-fail-with-a-snapshot-difference"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should fail with a snapshot difference
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.093s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                failed
+              </span>
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <div />
+                <button
+                  aria-controls="should-fail-with-a-snapshot-difference-diff"
+                  aria-expanded="false"
+                  class="btn btn-light btn-sm"
+                  data-target="#should-fail-with-a-snapshot-difference-diff"
+                  data-toggle="collapse"
+                  type="button"
+                >
+                  raw
+                </button>
+              </div>
+              <pre
+                class="collapse show"
+                id="should-fail-with-a-snapshot-difference-diff"
+              >
+                <code>
+                  <div>
+                    <span>
+                      Error: expect(value).toMatchSnapshot()
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span>
+                      Received value does not match stored snapshot 1.
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span
+                      style="color:#dc3545"
+                    >
+                      - Snapshot
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#28a745"
+                    >
+                      + Received
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span>
+                        "{
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#dc3545"
+                    >
+                      -   "name": "test",
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#28a745"
+                    >
+                      +   "name": "nest",
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          "breed": "beagle",
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          "height": 1,
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          "color": "brown and yellow"
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                        }"
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.it (jest-stare\\__tests__\\example\\FailingTests.test.ts:10:53)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.asyncFn (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at resolve (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at new Promise (&lt;anonymous&gt;)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at mapper (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at promise.then (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at &lt;anonymous&gt;
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at process._tickCallback (internal/process/next_tick.js:188:7)
+                    </span>
+                  </div>
+                </code>
+              </pre>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-be-a-placeholder"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should be a placeholder
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 failed-test"
+            id="should-fail-with-a-snapshot-difference-2"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should fail with a snapshot difference 2
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                failed
+              </span>
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <div />
+                <button
+                  aria-controls="should-fail-with-a-snapshot-difference-2-diff"
+                  aria-expanded="false"
+                  class="btn btn-light btn-sm"
+                  data-target="#should-fail-with-a-snapshot-difference-2-diff"
+                  data-toggle="collapse"
+                  type="button"
+                >
+                  raw
+                </button>
+              </div>
+              <pre
+                class="collapse show"
+                id="should-fail-with-a-snapshot-difference-2-diff"
+              >
+                <code>
+                  <div>
+                    <span>
+                      Error: expect(value).toMatchSnapshot()
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span>
+                      Received value does not match stored snapshot 1.
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span
+                      style="color:#dc3545"
+                    >
+                      - Snapshot
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#28a745"
+                    >
+                      + Received
+                    </span>
+                  </div>
+                  <div>
+                    <span />
+                  </div>
+                  <div>
+                    <span>
+                        "{
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          "name": "test",
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#dc3545"
+                    >
+                      -   "breed": "beagle",
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#dc3545"
+                    >
+                      -   "height": 1,
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#dc3545"
+                    >
+                      -   "color": "brown and yellow"
+                    </span>
+                  </div>
+                  <div>
+                    <span
+                      style="color:#28a745"
+                    >
+                      +   "breed": "beagle"
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                        }"
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.it (jest-stare\\__tests__\\example\\FailingTests.test.ts:21:53)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at Object.asyncFn (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at resolve (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at new Promise (&lt;anonymous&gt;)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at mapper (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at promise.then (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at &lt;anonymous&gt;
+                    </span>
+                  </div>
+                  <div>
+                    <span>
+                          at process._tickCallback (internal/process/next_tick.js:188:7)
+                    </span>
+                  </div>
+                </code>
+              </pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
+  >
+    <div
+      class="card-header"
+      id="jest-stare___tests___src_render_Render_test_ts_header"
+    >
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
+      >
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_render_Render_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\render\\Render.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_render_Render_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Render tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Render tests
           </h6>
           <div
             class="media text-muted pt-3 passed-test"
@@ -2130,6 +4591,219 @@ Array [
                 <small
                   class="d-block text-right mt-3"
                 >
+                  0.001s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
+  >
+    <div
+      class="card-header"
+      id="jest-stare___tests___src_processor_Processor_test_ts_header"
+    >
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
+      >
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_processor_Processor_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\processor\\Processor.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_processor_Processor_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Processor tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Processor tests
+          </h6>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-create-a-report-form-an-input-object"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should create a report form an input object
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.015s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-error-when-called-without-input"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should error when called without input
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>,
+  <div
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
+  >
+    <div
+      class="card-header"
+      id="jest-stare___tests___src_utils_IO_test_ts_header"
+    >
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
+      >
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_utils_IO_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\utils\\IO.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              4
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_utils_IO_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="IO tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            IO tests
+          </h6>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-pretend-to-write-to-a-file"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should pretend to write to a file
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
                   0.002s
                 </small>
               </div>
@@ -2141,2510 +4815,317 @@ Array [
             </div>
           </div>
           <div
-            class="my-3 p-3 bg-white rounded box-shadow passed-test"
-            id="outer 0.outer 1.outer 2.first outer 3"
+            class="media text-muted pt-3 passed-test"
+            id="should-pretend-to-write-to-a-file-and-reject-promise-for-io-errors"
           >
-            <h6
-              class="border-bottom pb-2 mb-0 display-6"
-            >
-              first outer 3
-            </h6>
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
             <div
-              class="my-3 p-3 bg-white rounded box-shadow passed-test"
-              id="outer 0.outer 1.outer 2.first outer 3.outer 4"
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
             >
-              <h6
-                class="border-bottom pb-2 mb-0 display-6"
-              >
-                outer 4
-              </h6>
               <div
-                class="media text-muted pt-3 passed-test"
-                id="should-pass"
+                class="d-flex justify-content-between align-items-center w-100"
               >
-                <img
-                  alt=""
-                  class="mr-2 rounded"
-                  data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-                />
-                <div
-                  class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                <strong
+                  class="text-gray-dark"
                 >
-                  <div
-                    class="d-flex justify-content-between align-items-center w-100"
-                  >
-                    <strong
-                      class="text-gray-dark"
-                    >
-                      should pass
-                    </strong>
-                    <small
-                      class="d-block text-right mt-3"
-                    >
-                      0s
-                    </small>
-                  </div>
-                  <span
-                    class="d-block mb-2"
-                  >
-                    passed
-                  </span>
-                </div>
+                  should pretend to write to a file and reject promise for IO errors
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0s
+                </small>
               </div>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
             </div>
           </div>
           <div
-            class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-            id="outer 0.outer 1.outer 2.outer 3"
+            class="media text-muted pt-3 passed-test"
+            id="should-say-true-if-dir-exists"
           >
-            <h6
-              class="border-bottom pb-2 mb-0 display-6"
-            >
-              outer 3
-            </h6>
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
             <div
-              class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-              id="outer 0.outer 1.outer 2.outer 3.outer 4"
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
             >
-              <h6
-                class="border-bottom pb-2 mb-0 display-6"
-              >
-                outer 4
-              </h6>
               <div
-                class="media text-muted pt-3 passed-test"
-                id="should-pass"
+                class="d-flex justify-content-between align-items-center w-100"
               >
-                <img
-                  alt=""
-                  class="mr-2 rounded"
-                  data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-                />
-                <div
-                  class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                <strong
+                  class="text-gray-dark"
                 >
-                  <div
-                    class="d-flex justify-content-between align-items-center w-100"
-                  >
-                    <strong
-                      class="text-gray-dark"
-                    >
-                      should pass
-                    </strong>
-                    <small
-                      class="d-block text-right mt-3"
-                    >
-                      0s
-                    </small>
-                  </div>
-                  <span
-                    class="d-block mb-2"
-                  >
-                    passed
-                  </span>
-                </div>
+                  should say true if dir exists
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.001s
+                </small>
               </div>
-              <div
-                class="media text-muted pt-3 failed-test"
-                id="should-fail"
+              <span
+                class="d-block mb-2"
               >
-                <img
-                  alt=""
-                  class="mr-2 rounded"
-                  data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
-                />
-                <div
-                  class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-                >
-                  <div
-                    class="d-flex justify-content-between align-items-center w-100"
-                  >
-                    <strong
-                      class="text-gray-dark"
-                    >
-                      should fail
-                    </strong>
-                    <small
-                      class="d-block text-right mt-3"
-                    >
-                      0.11s
-                    </small>
-                  </div>
-                  <span
-                    class="d-block mb-2"
-                  >
-                    failed
-                  </span>
-                  <div
-                    class="d-flex justify-content-between align-items-center w-100"
-                  >
-                    <div />
-                    <button
-                      aria-controls="should-fail-diff"
-                      aria-expanded="false"
-                      class="btn btn-light btn-sm"
-                      data-target="#should-fail-diff"
-                      data-toggle="collapse"
-                      type="button"
-                    >
-                      raw
-                    </button>
-                  </div>
-                  <pre
-                    class="collapse show"
-                    id="should-fail-diff"
-                  >
-                    <code>
-                      <div>
-                        <span>
-                          Error: expect(received).toBe(expected) // Object.is equality
-                        </span>
-                      </div>
-                      <div>
-                        <span />
-                      </div>
-                      <div>
-                        <span>
-                          Expected value to be:
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                            false
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                          Received:
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                            true
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at Object.it (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\NestedDescribeTests.example.ts:20:38)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at Object.asyncFn (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at resolve (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at new Promise (&lt;anonymous&gt;)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at mapper (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at promise.then (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at &lt;anonymous&gt;
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at process._tickCallback (internal/process/next_tick.js:188:7)
-                        </span>
-                      </div>
-                    </code>
-                  </pre>
-                </div>
-              </div>
+                passed
+              </span>
             </div>
           </div>
           <div
-            class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-            id="outer 0.outer 1.outer 2.next outer 3"
+            class="media text-muted pt-3 passed-test"
+            id="should-false-if-dir-does-not-exist"
           >
-            <h6
-              class="border-bottom pb-2 mb-0 display-6"
-            >
-              next outer 3
-            </h6>
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
             <div
-              class="media text-muted pt-3 passed-test"
-              id="should-be-around"
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
             >
-              <img
-                alt=""
-                class="mr-2 rounded"
-                data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-              />
               <div
-                class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+                class="d-flex justify-content-between align-items-center w-100"
               >
-                <div
-                  class="d-flex justify-content-between align-items-center w-100"
+                <strong
+                  class="text-gray-dark"
                 >
-                  <strong
-                    class="text-gray-dark"
-                  >
-                    should be around
-                  </strong>
-                  <small
-                    class="d-block text-right mt-3"
-                  >
-                    0s
-                  </small>
-                </div>
-                <span
-                  class="d-block mb-2"
+                  should false if dir does not exist
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
                 >
-                  passed
-                </span>
+                  0s
+                </small>
               </div>
-            </div>
-            <div
-              class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-              id="outer 0.outer 1.outer 2.next outer 3.outer 4"
-            >
-              <h6
-                class="border-bottom pb-2 mb-0 display-6"
+              <span
+                class="d-block mb-2"
               >
-                outer 4
-              </h6>
-              <div
-                class="media text-muted pt-3 passed-test"
-                id="should-pass"
-              >
-                <img
-                  alt=""
-                  class="mr-2 rounded"
-                  data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-                />
-                <div
-                  class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-                >
-                  <div
-                    class="d-flex justify-content-between align-items-center w-100"
-                  >
-                    <strong
-                      class="text-gray-dark"
-                    >
-                      should pass
-                    </strong>
-                    <small
-                      class="d-block text-right mt-3"
-                    >
-                      0s
-                    </small>
-                  </div>
-                  <span
-                    class="d-block mb-2"
-                  >
-                    passed
-                  </span>
-                </div>
-              </div>
-              <div
-                class="media text-muted pt-3 failed-test"
-                id="should-fail"
-              >
-                <img
-                  alt=""
-                  class="mr-2 rounded"
-                  data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
-                />
-                <div
-                  class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-                >
-                  <div
-                    class="d-flex justify-content-between align-items-center w-100"
-                  >
-                    <strong
-                      class="text-gray-dark"
-                    >
-                      should fail
-                    </strong>
-                    <small
-                      class="d-block text-right mt-3"
-                    >
-                      0s
-                    </small>
-                  </div>
-                  <span
-                    class="d-block mb-2"
-                  >
-                    failed
-                  </span>
-                  <div
-                    class="d-flex justify-content-between align-items-center w-100"
-                  >
-                    <div />
-                    <button
-                      aria-controls="should-fail-diff"
-                      aria-expanded="false"
-                      class="btn btn-light btn-sm"
-                      data-target="#should-fail-diff"
-                      data-toggle="collapse"
-                      type="button"
-                    >
-                      raw
-                    </button>
-                  </div>
-                  <pre
-                    class="collapse show"
-                    id="should-fail-diff"
-                  >
-                    <code>
-                      <div>
-                        <span>
-                          Error: expect(received).toBe(expected) // Object.is equality
-                        </span>
-                      </div>
-                      <div>
-                        <span />
-                      </div>
-                      <div>
-                        <span>
-                          Expected value to be:
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                            false
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                          Received:
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                            true
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at Object.it (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\NestedDescribeTests.example.ts:33:38)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at Object.asyncFn (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at resolve (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at new Promise (&lt;anonymous&gt;)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at mapper (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at promise.then (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at &lt;anonymous&gt;
-                        </span>
-                      </div>
-                      <div>
-                        <span>
-                              at process._tickCallback (internal/process/next_tick.js:188:7)
-                        </span>
-                      </div>
-                    </code>
-                  </pre>
-                </div>
-              </div>
-            </div>
-            <div
-              class="media text-muted pt-3 passed-test"
-              id="should-be-around-too"
-            >
-              <img
-                alt=""
-                class="mr-2 rounded"
-                data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-              />
-              <div
-                class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-              >
-                <div
-                  class="d-flex justify-content-between align-items-center w-100"
-                >
-                  <strong
-                    class="text-gray-dark"
-                  >
-                    should be around too
-                  </strong>
-                  <small
-                    class="d-block text-right mt-3"
-                  >
-                    0s
-                  </small>
-                </div>
-                <span
-                  class="d-block mb-2"
-                >
-                  passed
-                </span>
-              </div>
-            </div>
-          </div>
-          <div
-            class="my-3 p-3 bg-white rounded box-shadow passed-test"
-            id="outer 0.outer 1.outer 2.last outer 3"
-          >
-            <h6
-              class="border-bottom pb-2 mb-0 display-6"
-            >
-              last outer 3
-            </h6>
-            <div
-              class="my-3 p-3 bg-white rounded box-shadow passed-test"
-              id="outer 0.outer 1.outer 2.last outer 3.outer 4"
-            >
-              <h6
-                class="border-bottom pb-2 mb-0 display-6"
-              >
-                outer 4
-              </h6>
-              <div
-                class="media text-muted pt-3 passed-test"
-                id="should-pass"
-              >
-                <img
-                  alt=""
-                  class="mr-2 rounded"
-                  data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-                />
-                <div
-                  class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-                >
-                  <div
-                    class="d-flex justify-content-between align-items-center w-100"
-                  >
-                    <strong
-                      class="text-gray-dark"
-                    >
-                      should pass
-                    </strong>
-                    <small
-                      class="d-block text-right mt-3"
-                    >
-                      0s
-                    </small>
-                  </div>
-                  <span
-                    class="d-block mb-2"
-                  >
-                    passed
-                  </span>
-                </div>
-              </div>
+                passed
+              </span>
             </div>
           </div>
         </div>
       </div>
     </div>
   </div>,
-]
-`;
-
-exports[`TestSuite tests should create proper elements for passing and failing image snapshots 1`] = `
-Array [
   <div
-    class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-    id="/tmp/jest-stare/__tests__/__examples__/foo.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      /tmp/jest-stare/__tests__/__examples__/foo.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-      id="image snapshot test"
+      class="card-header"
+      id="jest-stare___tests___src_utils_Logger_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        image snapshot test
-      </h6>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-pass-with-image-snapshot"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_utils_Logger_test_ts_detail"
+          data-toggle="collapse"
         >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should pass with image snapshot
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.109s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 failed-test"
-        id="should-fail-with-image-snapshot"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should fail with image snapshot
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.213s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            failed
-          </span>
-          <div
-            class="image-snapshot-diff"
-          >
+          jest-stare\\__tests__\\src\\utils\\Logger.test.ts
+          <div>
             <span
-              class="text-muted"
+              class="badge badge-success border"
             >
-              Expected image to match or be a close match to snapshot but was 10.4736328125% different from snapshot (429 differing pixels).
+              1
             </span>
-            <a
-              href="image_snapshot_diff/foo-ts-image-snapshot-test-should-fail-with-image-snapshot-1-diff.png"
-            >
-              <img
-                src="image_snapshot_diff/foo-ts-image-snapshot-test-should-fail-with-image-snapshot-1-diff.png"
-              />
-            </a>
-          </div>
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <div />
-            <button
-              aria-controls="should-fail-with-image-snapshot-diff"
-              aria-expanded="false"
-              class="btn btn-light btn-sm"
-              data-target="#should-fail-with-image-snapshot-diff"
-              data-toggle="collapse"
-              type="button"
-            >
-              raw
-            </button>
-          </div>
-          <pre
-            class="collapse"
-            id="should-fail-with-image-snapshot-diff"
-          >
-            <code>
-              <div>
-                <span>
-                  Error: Expected image to match or be a close match to snapshot but was 10.4736328125% different from snapshot (429 differing pixels).
-                </span>
-              </div>
-              <div>
-                <span>
-                  See diff for details: /tmp/jest-stare/__tests__/__examples__/__image_snapshots__/__diff_output__/foo-ts-image-snapshot-test-should-fail-with-image-snapshot-1-diff.png
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.it (/tmp/jest-stare/__tests__/__examples__/foo.ts:17:29)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.asyncFn (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/jasmine_async.js:82:37)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at resolve (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:52:12)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at new Promise (&lt;anonymous&gt;)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at mapper (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:39:19)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at promise.then (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:73:82)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at &lt;anonymous&gt;
-                </span>
-              </div>
-              <div>
-                <span>
-                      at process._tickCallback (internal/process/next_tick.js:188:7)
-                </span>
-              </div>
-            </code>
-          </pre>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 failed-test"
-        id="should-fail-with-another-image-snapshot"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should fail with another image snapshot
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.213s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            failed
-          </span>
-          <div
-            class="image-snapshot-diff"
-          >
             <span
-              class="text-muted"
+              class="badge badge-danger border"
             >
-              Expected image to match or be a close match to snapshot but was 10.4736328125% different from snapshot (429 differing pixels).
+              0
             </span>
-            <a
-              href="image_snapshot_diff/foo-ts-image-snapshot-test-should-fail-with-another-image-snapshot-1-diff.png"
+            <span
+              class="badge badge-warning border"
             >
-              <img
-                src="image_snapshot_diff/foo-ts-image-snapshot-test-should-fail-with-another-image-snapshot-1-diff.png"
-              />
-            </a>
+              0
+            </span>
           </div>
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <div />
-            <button
-              aria-controls="should-fail-with-another-image-snapshot-diff"
-              aria-expanded="false"
-              class="btn btn-light btn-sm"
-              data-target="#should-fail-with-another-image-snapshot-diff"
-              data-toggle="collapse"
-              type="button"
-            >
-              raw
-            </button>
-          </div>
-          <pre
-            class="collapse"
-            id="should-fail-with-another-image-snapshot-diff"
-          >
-            <code>
-              <div>
-                <span>
-                  Error: Expected image to match or be a close match to snapshot but was 10.4736328125% different from snapshot (429 differing pixels).
-                </span>
-              </div>
-              <div>
-                <span>
-                  See diff for details: /tmp/jest-stare/__tests__/__examples__/__image_snapshots__/__diff_output__/foo-ts-image-snapshot-test-should-fail-with-another-image-snapshot-1-diff.png
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.it (/tmp/jest-stare/__tests__/__examples__/foo.ts:17:29)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.asyncFn (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/jasmine_async.js:82:37)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at resolve (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:52:12)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at new Promise (&lt;anonymous&gt;)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at mapper (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:39:19)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at promise.then (/tmp/jest-stare/node_modules/jest-config/node_modules/jest-jasmine2/build/queue_runner.js:73:82)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at &lt;anonymous&gt;
-                </span>
-              </div>
-              <div>
-                <span>
-                      at process._tickCallback (internal/process/next_tick.js:188:7)
-                </span>
-              </div>
-            </code>
-          </pre>
-        </div>
-      </div>
+        </button>
+      </h5>
     </div>
-  </div>,
-]
-`;
-
-exports[`TestSuite tests should create proper elements for pending tests 1`] = `
-Array [
-  <div
-    class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test.pending-test"
-    id="C:\\\\Users\\\\KELDA16\\\\Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\__examples__\\\\PendingTests.example.ts"
-  >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\PendingTests.example.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test.pending-test"
-      id="pending tests"
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_utils_Logger_test_ts_detail"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
-      >
-        pending tests
-      </h6>
       <div
-        class="media text-muted pt-3 pending-test"
-        id="should-pend"
+        class="card-body"
       >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=ffc107&fg=ffc107&size=1"
-        />
         <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Logger tests"
         >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Logger tests
+          </h6>
           <div
-            class="d-flex justify-content-between align-items-center w-100"
+            class="media text-muted pt-3 passed-test"
+            id="should-get-a-log-instance"
           >
-            <strong
-              class="text-gray-dark"
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
             >
-              should pend
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            pending
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-pass"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should pass
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 failed-test"
-        id="should-fail"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should fail
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.09s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            failed
-          </span>
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <div />
-            <button
-              aria-controls="should-fail-diff"
-              aria-expanded="false"
-              class="btn btn-light btn-sm"
-              data-target="#should-fail-diff"
-              data-toggle="collapse"
-              type="button"
-            >
-              raw
-            </button>
-          </div>
-          <pre
-            class="collapse show"
-            id="should-fail-diff"
-          >
-            <code>
-              <div>
-                <span>
-                  Error: Failure here
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.it (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\PendingTests.example.ts:9:15)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.asyncFn (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at resolve (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at new Promise (&lt;anonymous&gt;)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at mapper (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at promise.then (C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at &lt;anonymous&gt;
-                </span>
-              </div>
-              <div>
-                <span>
-                      at process._tickCallback (internal/process/next_tick.js:188:7)
-                </span>
-              </div>
-            </code>
-          </pre>
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`TestSuite tests should create proper elements for simple failing tests 1`] = `
-Array [
-  <div
-    class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-    id="Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\utils\\\\IO.test.ts"
-  >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts
-    </h5>
-    <div
-      class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-      id="IO tests"
-    >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
-      >
-        IO tests
-      </h6>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-pretend-to-write-to-a-file"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should pretend to write to a file
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.003s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-match-snapshot-with-one-field"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should match snapshot with one field
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.003s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 failed-test"
-        id="should-match-snapshot-with-two-fields"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should match snapshot with two fields
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.14s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            failed
-          </span>
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <div />
-            <button
-              aria-controls="should-match-snapshot-with-two-fields-diff"
-              aria-expanded="false"
-              class="btn btn-light btn-sm"
-              data-target="#should-match-snapshot-with-two-fields-diff"
-              data-toggle="collapse"
-              type="button"
-            >
-              raw
-            </button>
-          </div>
-          <pre
-            class="collapse show"
-            id="should-match-snapshot-with-two-fields-diff"
-          >
-            <code>
-              <div>
-                <span>
-                  Error: expect(value).toMatchSnapshot()
-                </span>
-              </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span>
-                  Received value does not match stored snapshot 1.
-                </span>
-              </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span
-                  style="color:#dc3545"
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
                 >
-                  - Snapshot
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#28a745"
+                  should get a log instance
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
                 >
-                  + Received
-                </span>
+                  0s
+                </small>
               </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span>
-                    Object {
-                </span>
-              </div>
-              <div>
-                <span>
-                      "name": "someone",
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#28a745"
-                >
-                  +   "newThing": "here",
-                </span>
-              </div>
-              <div>
-                <span>
-                      "password": "secret",
-                </span>
-              </div>
-              <div>
-                <span>
-                    }
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.it (Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts:40:22)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.asyncFn (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at resolve (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at new Promise (&lt;anonymous&gt;)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at mapper (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at promise.then (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at &lt;anonymous&gt;
-                </span>
-              </div>
-              <div>
-                <span>
-                      at process._tickCallback (internal/process/next_tick.js:188:7)
-                </span>
-              </div>
-            </code>
-          </pre>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 failed-test"
-        id="should-match-snapshot-with-three-fields"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should match snapshot with three fields
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.001s
-            </small>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
           </div>
-          <span
-            class="d-block mb-2"
-          >
-            failed
-          </span>
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <div />
-            <button
-              aria-controls="should-match-snapshot-with-three-fields-diff"
-              aria-expanded="false"
-              class="btn btn-light btn-sm"
-              data-target="#should-match-snapshot-with-three-fields-diff"
-              data-toggle="collapse"
-              type="button"
-            >
-              raw
-            </button>
-          </div>
-          <pre
-            class="collapse show"
-            id="should-match-snapshot-with-three-fields-diff"
-          >
-            <code>
-              <div>
-                <span>
-                  Error: expect(value).toMatchSnapshot()
-                </span>
-              </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span>
-                  Received value does not match stored snapshot 1.
-                </span>
-              </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span
-                  style="color:#dc3545"
-                >
-                  - Snapshot
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#28a745"
-                >
-                  + Received
-                </span>
-              </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span>
-                    Object {
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#dc3545"
-                >
-                  -   "data": "sample",
-                </span>
-              </div>
-              <div>
-                <span>
-                      "name": "someone",
-                </span>
-              </div>
-              <div>
-                <span>
-                      "password": "secret",
-                </span>
-              </div>
-              <div>
-                <span>
-                    }
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.it (Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts:48:22)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.asyncFn (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at resolve (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at new Promise (&lt;anonymous&gt;)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at mapper (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at promise.then (AppData\\Roaming\\npm\\node_modules\\jest\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at &lt;anonymous&gt;
-                </span>
-              </div>
-              <div>
-                <span>
-                      at process._tickCallback (internal/process/next_tick.js:188:7)
-                </span>
-              </div>
-            </code>
-          </pre>
         </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\reporter\\\\Reporter.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      Work\\Dev\\node\\jest-stare\\__tests__\\reporter\\Reporter.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Reporter tests"
+      class="card-header"
+      id="jest-stare___tests___src_reporter_Reporter_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Reporter tests
-      </h6>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-instantiate-reporter-class"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_reporter_Reporter_test_ts_detail"
+          data-toggle="collapse"
         >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
+          jest-stare\\__tests__\\src\\reporter\\Reporter.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
             >
-              should instantiate Reporter class
-            </strong>
-            <small
-              class="d-block text-right mt-3"
+              2
+            </span>
+            <span
+              class="badge badge-danger border"
             >
-              0.001s
-            </small>
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
           </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
+        </button>
+      </h5>
     </div>
-  </div>,
-]
-`;
-
-exports[`TestSuite tests should create proper elements for simple passing tests 1`] = `
-Array [
-  <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\utils\\\\IO.test.ts"
-  >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="IO tests"
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_reporter_Reporter_test_ts_detail"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
-      >
-        IO tests
-      </h6>
       <div
-        class="media text-muted pt-3 passed-test"
-        id="should-pretend-to-write-to-a-file"
+        class="card-body"
       >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
         <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Reporter tests"
         >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Reporter tests
+          </h6>
           <div
-            class="d-flex justify-content-between align-items-center w-100"
+            class="media text-muted pt-3 passed-test"
+            id="should-instantiate-reporter-class"
           >
-            <strong
-              class="text-gray-dark"
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
             >
-              should pretend to write to a file
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.003s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-match-snapshot-with-one-field"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should match snapshot with one field
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.001s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-match-snapshot-with-two-fields"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should match snapshot with two fields
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.001s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-match-snapshot-with-three-fields"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should match snapshot with three fields
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\reporter\\\\Reporter.test.ts"
-  >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      Work\\Dev\\node\\jest-stare\\__tests__\\reporter\\Reporter.test.ts
-    </h5>
-    <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Reporter tests"
-    >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
-      >
-        Reporter tests
-      </h6>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-instantiate-reporter-class"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should instantiate Reporter class
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.001s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`TestSuite tests should create proper elements for two diffs in html 1`] = `
-Array [
-  <div
-    class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-    id="jest-stare\\\\__tests__\\\\example\\\\FailingTests.test.ts"
-  >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\example\\FailingTests.test.ts
-    </h5>
-    <div
-      class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-      id="Failing Tests"
-    >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
-      >
-        Failing Tests
-      </h6>
-      <div
-        class="media text-muted pt-3 failed-test"
-        id="should-fail-with-a-snapshot-difference"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should fail with a snapshot difference
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.093s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            failed
-          </span>
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <div />
-            <button
-              aria-controls="should-fail-with-a-snapshot-difference-diff"
-              aria-expanded="false"
-              class="btn btn-light btn-sm"
-              data-target="#should-fail-with-a-snapshot-difference-diff"
-              data-toggle="collapse"
-              type="button"
-            >
-              raw
-            </button>
-          </div>
-          <pre
-            class="collapse show"
-            id="should-fail-with-a-snapshot-difference-diff"
-          >
-            <code>
-              <div>
-                <span>
-                  Error: expect(value).toMatchSnapshot()
-                </span>
-              </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span>
-                  Received value does not match stored snapshot 1.
-                </span>
-              </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span
-                  style="color:#dc3545"
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
                 >
-                  - Snapshot
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#28a745"
+                  should instantiate Reporter class
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
                 >
-                  + Received
-                </span>
+                  0.001s
+                </small>
               </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span>
-                    "{
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#dc3545"
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
+          </div>
+          <div
+            class="media text-muted pt-3 passed-test"
+            id="should-do-something"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
                 >
-                  -   "name": "test",
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#28a745"
+                  should do something
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
                 >
-                  +   "name": "nest",
-                </span>
+                  0.001s
+                </small>
               </div>
-              <div>
-                <span>
-                      "breed": "beagle",
-                </span>
-              </div>
-              <div>
-                <span>
-                      "height": 1,
-                </span>
-              </div>
-              <div>
-                <span>
-                      "color": "brown and yellow"
-                </span>
-              </div>
-              <div>
-                <span>
-                    }"
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.it (jest-stare\\__tests__\\example\\FailingTests.test.ts:10:53)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.asyncFn (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at resolve (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at new Promise (&lt;anonymous&gt;)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at mapper (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at promise.then (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at &lt;anonymous&gt;
-                </span>
-              </div>
-              <div>
-                <span>
-                      at process._tickCallback (internal/process/next_tick.js:188:7)
-                </span>
-              </div>
-            </code>
-          </pre>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-be-a-placeholder"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should be a placeholder
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0s
-            </small>
+              <span
+                class="d-block mb-2"
+              >
+                passed
+              </span>
+            </div>
           </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 failed-test"
-        id="should-fail-with-a-snapshot-difference-2"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=dc3545&fg=dc3545&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should fail with a snapshot difference 2
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            failed
-          </span>
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <div />
-            <button
-              aria-controls="should-fail-with-a-snapshot-difference-2-diff"
-              aria-expanded="false"
-              class="btn btn-light btn-sm"
-              data-target="#should-fail-with-a-snapshot-difference-2-diff"
-              data-toggle="collapse"
-              type="button"
-            >
-              raw
-            </button>
-          </div>
-          <pre
-            class="collapse show"
-            id="should-fail-with-a-snapshot-difference-2-diff"
-          >
-            <code>
-              <div>
-                <span>
-                  Error: expect(value).toMatchSnapshot()
-                </span>
-              </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span>
-                  Received value does not match stored snapshot 1.
-                </span>
-              </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span
-                  style="color:#dc3545"
-                >
-                  - Snapshot
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#28a745"
-                >
-                  + Received
-                </span>
-              </div>
-              <div>
-                <span />
-              </div>
-              <div>
-                <span>
-                    "{
-                </span>
-              </div>
-              <div>
-                <span>
-                      "name": "test",
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#dc3545"
-                >
-                  -   "breed": "beagle",
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#dc3545"
-                >
-                  -   "height": 1,
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#dc3545"
-                >
-                  -   "color": "brown and yellow"
-                </span>
-              </div>
-              <div>
-                <span
-                  style="color:#28a745"
-                >
-                  +   "breed": "beagle"
-                </span>
-              </div>
-              <div>
-                <span>
-                    }"
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.it (jest-stare\\__tests__\\example\\FailingTests.test.ts:21:53)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at Object.asyncFn (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\jasmine_async.js:129:432)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at resolve (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:51:12)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at new Promise (&lt;anonymous&gt;)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at mapper (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:40:274)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at promise.then (jest-stare\\node_modules\\jest-config\\node_modules\\jest-jasmine2\\build\\queue_runner.js:83:39)
-                </span>
-              </div>
-              <div>
-                <span>
-                      at &lt;anonymous&gt;
-                </span>
-              </div>
-              <div>
-                <span>
-                      at process._tickCallback (internal/process/next_tick.js:188:7)
-                </span>
-              </div>
-            </code>
-          </pre>
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\render\\\\Render.test.ts"
-  >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\render\\Render.test.ts
-    </h5>
-    <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Render tests"
-    >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
-      >
-        Render tests
-      </h6>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-pass"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should pass
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.001s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\processor\\\\Processor.test.ts"
-  >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\processor\\Processor.test.ts
-    </h5>
-    <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Processor tests"
-    >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
-      >
-        Processor tests
-      </h6>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-create-a-report-form-an-input-object"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should create a report form an input object
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.015s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-error-when-called-without-input"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should error when called without input
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\utils\\\\IO.test.ts"
-  >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\utils\\IO.test.ts
-    </h5>
-    <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="IO tests"
-    >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
-      >
-        IO tests
-      </h6>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-pretend-to-write-to-a-file"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should pretend to write to a file
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.002s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-pretend-to-write-to-a-file-and-reject-promise-for-io-errors"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should pretend to write to a file and reject promise for IO errors
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-say-true-if-dir-exists"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should say true if dir exists
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.001s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-false-if-dir-does-not-exist"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should false if dir does not exist
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\utils\\\\Logger.test.ts"
-  >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\utils\\Logger.test.ts
-    </h5>
-    <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Logger tests"
-    >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
-      >
-        Logger tests
-      </h6>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-get-a-log-instance"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should get a log instance
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-    </div>
-  </div>,
-  <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\reporter\\\\Reporter.test.ts"
-  >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\reporter\\Reporter.test.ts
-    </h5>
-    <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Reporter tests"
-    >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
-      >
-        Reporter tests
-      </h6>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-instantiate-reporter-class"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should instantiate Reporter class
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.001s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
-        </div>
-      </div>
-      <div
-        class="media text-muted pt-3 passed-test"
-        id="should-do-something"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=28a745&fg=28a745&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
-        >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
-            >
-              should do something
-            </strong>
-            <small
-              class="d-block text-right mt-3"
-            >
-              0.001s
-            </small>
-          </div>
-          <span
-            class="d-block mb-2"
-          >
-            passed
-          </span>
         </div>
       </div>
     </div>
@@ -4655,54 +5136,91 @@ Array [
 exports[`TestSuite tests should show no red box if all tests are pending 1`] = `
 Array [
   <div
-    class="my-3 p-3 bg-white rounded box-shadow pending-test"
-    id="C:\\\\Users\\\\KELDA16\\\\Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\__examples__\\\\PendingTestsOnly.example.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card pending-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\PendingTestsOnly.example.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow pending-test"
-      id="pending tests"
+      class="card-header"
+      id="C__Users_KELDA16_Work_Dev_node_jest-stare___tests_____examples___PendingTestsOnly_example_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        pending tests
-      </h6>
-      <div
-        class="media text-muted pt-3 pending-test"
-        id="should-pend"
-      >
-        <img
-          alt=""
-          class="mr-2 rounded"
-          data-src="holder.js/32x32?theme=thumb&bg=ffc107&fg=ffc107&size=1"
-        />
-        <div
-          class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+        <button
+          class="btn btn-block"
+          data-target="#C__Users_KELDA16_Work_Dev_node_jest-stare___tests_____examples___PendingTestsOnly_example_ts_detail"
+          data-toggle="collapse"
         >
-          <div
-            class="d-flex justify-content-between align-items-center w-100"
-          >
-            <strong
-              class="text-gray-dark"
+          C:\\Users\\KELDA16\\Work\\Dev\\node\\jest-stare\\__tests__\\__examples__\\PendingTestsOnly.example.ts
+          <div>
+            <span
+              class="badge badge-success border"
             >
-              should pend
-            </strong>
-            <small
-              class="d-block text-right mt-3"
+              0
+            </span>
+            <span
+              class="badge badge-danger border"
             >
-              0.002s
-            </small>
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              1
+            </span>
           </div>
-          <span
-            class="d-block mb-2"
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="C__Users_KELDA16_Work_Dev_node_jest-stare___tests_____examples___PendingTestsOnly_example_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow pending-test"
+          id="pending tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
           >
-            pending
-          </span>
+            pending tests
+          </h6>
+          <div
+            class="media text-muted pt-3 pending-test"
+            id="should-pend"
+          >
+            <img
+              alt=""
+              class="mr-2 rounded"
+              data-src="holder.js/32x32?theme=thumb&bg=ffc107&fg=ffc107&size=1"
+            />
+            <div
+              class="media-body pb-3 mb-0 small lh-125 border-bottom overflow-auto"
+            >
+              <div
+                class="d-flex justify-content-between align-items-center w-100"
+              >
+                <strong
+                  class="text-gray-dark"
+                >
+                  should pend
+                </strong>
+                <small
+                  class="d-block text-right mt-3"
+                >
+                  0.002s
+                </small>
+              </div>
+              <span
+                class="d-block mb-2"
+              >
+                pending
+              </span>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/__tests__/render/suites/__snapshots__/TestSuite.test.ts.snap
+++ b/__tests__/render/suites/__snapshots__/TestSuite.test.ts.snap
@@ -3,161 +3,383 @@
 exports[`TestSuite tests Snapshots should create proper elements for large test more than 500 tests 1`] = `
 Array [
   <div
-    class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-    id="jest-stare\\\\__tests__\\\\example\\\\FailingTests.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card failed-test.passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\example\\FailingTests.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-      id="Failing Tests"
+      class="card-header"
+      id="jest-stare___tests___example_FailingTests_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Failing Tests
-      </h6>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___example_FailingTests_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\example\\FailingTests.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___example_FailingTests_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+          id="Failing Tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Failing Tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\render\\\\Render.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\render\\Render.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Render tests"
+      class="card-header"
+      id="jest-stare___tests___src_render_Render_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Render tests
-      </h6>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_render_Render_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\render\\Render.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_render_Render_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Render tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Render tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\processor\\\\Processor.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\processor\\Processor.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Processor tests"
+      class="card-header"
+      id="jest-stare___tests___src_processor_Processor_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Processor tests
-      </h6>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_processor_Processor_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\processor\\Processor.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_processor_Processor_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Processor tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Processor tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\utils\\\\IO.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\utils\\IO.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="IO tests"
+      class="card-header"
+      id="jest-stare___tests___src_utils_IO_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        IO tests
-      </h6>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_utils_IO_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\utils\\IO.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              4
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_utils_IO_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="IO tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            IO tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\utils\\\\Logger.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\utils\\Logger.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Logger tests"
+      class="card-header"
+      id="jest-stare___tests___src_utils_Logger_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Logger tests
-      </h6>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_utils_Logger_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\utils\\Logger.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_utils_Logger_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Logger tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Logger tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\reporter\\\\Reporter.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\reporter\\Reporter.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Reporter tests"
+      class="card-header"
+      id="jest-stare___tests___src_reporter_Reporter_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Reporter tests
-      </h6>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_reporter_Reporter_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\reporter\\Reporter.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_reporter_Reporter_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Reporter tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Reporter tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
@@ -167,57 +389,131 @@ Array [
 exports[`TestSuite tests Snapshots should create proper elements for simple failing tests 1`] = `
 Array [
   <div
-    class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-    id="Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\utils\\\\IO.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card failed-test.passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-      id="IO tests"
+      class="card-header"
+      id="Work_Dev_node_jest-stare___tests___utils_IO_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        IO tests
-      </h6>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#Work_Dev_node_jest-stare___tests___utils_IO_test_ts_detail"
+          data-toggle="collapse"
+        >
+          Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="Work_Dev_node_jest-stare___tests___utils_IO_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+          id="IO tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            IO tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\reporter\\\\Reporter.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      Work\\Dev\\node\\jest-stare\\__tests__\\reporter\\Reporter.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Reporter tests"
+      class="card-header"
+      id="Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Reporter tests
-      </h6>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_detail"
+          data-toggle="collapse"
+        >
+          Work\\Dev\\node\\jest-stare\\__tests__\\reporter\\Reporter.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Reporter tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Reporter tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
@@ -227,57 +523,131 @@ Array [
 exports[`TestSuite tests Snapshots should create proper elements for simple passing tests 1`] = `
 Array [
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\utils\\\\IO.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="IO tests"
+      class="card-header"
+      id="Work_Dev_node_jest-stare___tests___utils_IO_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        IO tests
-      </h6>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#Work_Dev_node_jest-stare___tests___utils_IO_test_ts_detail"
+          data-toggle="collapse"
+        >
+          Work\\Dev\\node\\jest-stare\\__tests__\\utils\\IO.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              4
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="Work_Dev_node_jest-stare___tests___utils_IO_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="IO tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            IO tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="Work\\\\Dev\\\\node\\\\jest-stare\\\\__tests__\\\\reporter\\\\Reporter.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      Work\\Dev\\node\\jest-stare\\__tests__\\reporter\\Reporter.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Reporter tests"
+      class="card-header"
+      id="Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Reporter tests
-      </h6>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_detail"
+          data-toggle="collapse"
+        >
+          Work\\Dev\\node\\jest-stare\\__tests__\\reporter\\Reporter.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="Work_Dev_node_jest-stare___tests___reporter_Reporter_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Reporter tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Reporter tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
@@ -287,161 +657,383 @@ Array [
 exports[`TestSuite tests Snapshots should create proper elements for two diffs in html 1`] = `
 Array [
   <div
-    class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-    id="jest-stare\\\\__tests__\\\\example\\\\FailingTests.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card failed-test.passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\example\\FailingTests.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
-      id="Failing Tests"
+      class="card-header"
+      id="jest-stare___tests___example_FailingTests_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Failing Tests
-      </h6>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___example_FailingTests_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\example\\FailingTests.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___example_FailingTests_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow failed-test.passed-test"
+          id="Failing Tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Failing Tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\render\\\\Render.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\render\\Render.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Render tests"
+      class="card-header"
+      id="jest-stare___tests___src_render_Render_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Render tests
-      </h6>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_render_Render_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\render\\Render.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_render_Render_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Render tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Render tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\processor\\\\Processor.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\processor\\Processor.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Processor tests"
+      class="card-header"
+      id="jest-stare___tests___src_processor_Processor_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Processor tests
-      </h6>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_processor_Processor_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\processor\\Processor.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_processor_Processor_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Processor tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Processor tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\utils\\\\IO.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\utils\\IO.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="IO tests"
+      class="card-header"
+      id="jest-stare___tests___src_utils_IO_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        IO tests
-      </h6>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_utils_IO_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\utils\\IO.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              4
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_utils_IO_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="IO tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            IO tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\utils\\\\Logger.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\utils\\Logger.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Logger tests"
+      class="card-header"
+      id="jest-stare___tests___src_utils_Logger_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Logger tests
-      </h6>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_utils_Logger_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\utils\\Logger.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              1
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_utils_Logger_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Logger tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Logger tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,
   <div
-    class="my-3 p-3 bg-white rounded box-shadow passed-test"
-    id="jest-stare\\\\__tests__\\\\src\\\\reporter\\\\Reporter.test.ts"
+    class="my-3 p-3 bg-white rounded box-shadow card passed-test"
   >
-    <h5
-      class="border-bottom pb-2 mb-0 display-5"
-    >
-      jest-stare\\__tests__\\src\\reporter\\Reporter.test.ts
-    </h5>
     <div
-      class="my-3 p-3 bg-white rounded box-shadow passed-test"
-      id="Reporter tests"
+      class="card-header"
+      id="jest-stare___tests___src_reporter_Reporter_test_ts_header"
     >
-      <h6
-        class="border-bottom pb-2 mb-0 display-6"
+      <h5
+        class="border-bottom pb-2 mb-0 display-5"
       >
-        Reporter tests
-      </h6>
-      <div>
-        dummy div
-      </div>
-      <div>
-        dummy div
+        <button
+          class="btn btn-block"
+          data-target="#jest-stare___tests___src_reporter_Reporter_test_ts_detail"
+          data-toggle="collapse"
+        >
+          jest-stare\\__tests__\\src\\reporter\\Reporter.test.ts
+          <div>
+            <span
+              class="badge badge-success border"
+            >
+              2
+            </span>
+            <span
+              class="badge badge-danger border"
+            >
+              0
+            </span>
+            <span
+              class="badge badge-warning border"
+            >
+              0
+            </span>
+          </div>
+        </button>
+      </h5>
+    </div>
+    <div
+      class="collapse"
+      data-parent="#accordion"
+      id="jest-stare___tests___src_reporter_Reporter_test_ts_detail"
+    >
+      <div
+        class="card-body"
+      >
+        <div
+          class="my-3 p-3 bg-white rounded box-shadow passed-test"
+          id="Reporter tests"
+        >
+          <h6
+            class="border-bottom pb-2 mb-0 display-6"
+          >
+            Reporter tests
+          </h6>
+          <div>
+            dummy div
+          </div>
+          <div>
+            dummy div
+          </div>
+        </div>
       </div>
     </div>
   </div>,

--- a/web/template.html
+++ b/web/template.html
@@ -109,7 +109,9 @@
 
         <div class="d-none" id="test-summary">{{testSummary}}</div>
         <div class="d-none" id="test-config">{{rawJestStareConfig}}</div>
-        <div class="d-none" id="test-results">{{rawResults}}</div>
+        <div id="accordion">
+            <div class="d-none" id="test-results">{{rawResults}}</div>
+        </div>
         <div class="d-none" id="test-global-config">{{globalConfig}}</div>
 
     </main>


### PR DESCRIPTION
I took a stab at addressing #216 using [Bootstrap Accordion](https://getbootstrap.com/docs/4.0/components/collapse/#accordion-example).  Collapsible sections will be based on `testFileName` from the Jest output and will default as collapsed.  Also provided badge icons to see the count of pass, fail, pending tests within a section.

Sample report is attached. No hurt feelings if this doesn't meet what you were expecting.  Will make adjustments based on suggestions.

[jest-stare.zip](https://github.com/dkelosky/jest-stare/files/4451122/jest-stare.zip)
