### PR TITLE
Adding support for jest.todo tests

### DIFF
--- a/src/processor/doc/IJestStareConfig.ts
+++ b/src/processor/doc/IJestStareConfig.ts
@@ -122,6 +122,13 @@ export interface IJestStareConfig {
      * @memberof IJestStareConfig
      */
     hidePending?: boolean;
+
+    /**
+     * Set to true to hide todo tests in the HTML report
+     * @type {boolean}
+     * @memberof IJestStareConfig
+     */
+    hideTodo?: boolean;
 }
 
 /**

--- a/src/render/Constants.ts
+++ b/src/render/Constants.ts
@@ -27,6 +27,13 @@ export class Constants {
     public static readonly PENDING_LABEL = "Pending";
 
     /**
+     * Label for todo tests
+     * @static
+     * @memberof Constants
+     */
+    public static readonly TODO_LABEL = "Todo";
+
+    /**
      * Label for obsolete info
      * @static
      * @memberof Constants
@@ -89,6 +96,13 @@ export class Constants {
      * @memberof Constants
      */
     public static readonly TEST_STATUS_PEND = "pending";
+
+    /**
+     * Todo jest status
+     * @static
+     * @memberof Constants
+     */
+    public static readonly TEST_STATUS_TODO = "todo";
 
     /**
      * Obsolete snapshot file
@@ -157,6 +171,14 @@ export class Constants {
     public static readonly PENDING = "#" + Constants.PENDING_RAW; // btn-warning
 
     /**
+     * Todo color
+     * @static
+     * @memberof Constants
+     */
+    public static readonly TODO_RAW = "17a2b8";
+    public static readonly TODO = "#" + Constants.TODO_RAW;
+
+    /**
      * Passed test class
      * @static
      * @memberof Constants
@@ -176,4 +198,11 @@ export class Constants {
      * @memberof Constants
      */
     public static readonly PENDING_TEST = "pending-test";
+
+     /**
+     * Pending test class
+     * @static
+     * @memberof Constants
+     */
+    public static readonly TODO_TEST = "todo-test";
 }

--- a/src/render/Render.ts
+++ b/src/render/Render.ts
@@ -80,7 +80,7 @@ export class Render {
             Doughnut.createChart($("#test-suites-canvas") as JQuery<HTMLCanvasElement>, suitesData);
 
             // build tests chart
-            const testsChart = Render.buildChartsData(results.numPassedTests, results.numFailedTests, results.numPendingTests);
+            const testsChart = Render.buildChartsData(results.numPassedTests, results.numFailedTests, results.numPendingTests, results.numTodoTests);
             Doughnut.createChart($("#tests-canvas") as JQuery<HTMLCanvasElement>, testsChart);
 
             // base snapshot data
@@ -122,6 +122,12 @@ export class Render {
             $(`.${Constants.PENDING_TEST}`).hide();
         }
 
+        // hide todo tests
+        if (config.hideTodo) {
+            $("#lab-todooff-switch").prop("checked", false);
+            $(`.${Constants.TODO_TEST}`).hide();
+        }
+
         if (config.hideFailing && config.hidePassing) {
             $(`.${Constants.FAILED_TEST}\\.${Constants.PASSED_TEST}`).hide();
         }
@@ -143,9 +149,10 @@ export class Render {
         allCheckArray.push($("#lab-passoff-switch") as JQuery<HTMLInputElement>);
         allCheckArray.push($("#lab-failoff-switch") as JQuery<HTMLInputElement>);
         allCheckArray.push($("#lab-pendingoff-switch") as JQuery<HTMLInputElement>);
+        allCheckArray.push($("#lab-todooff-switch") as JQuery<HTMLInputElement>);
 
-        const allStylesArray = [Constants.PASSED_TEST, Constants.FAILED_TEST, Constants.PENDING_TEST];
-        const allSwitchArray = ["#lab-passoff-switch", "#lab-failoff-switch", "#lab-pendingoff-switch"];
+        const allStylesArray = [Constants.PASSED_TEST, Constants.FAILED_TEST, Constants.PENDING_TEST, Constants.TODO_TEST];
+        const allSwitchArray = ["#lab-passoff-switch", "#lab-failoff-switch", "#lab-pendingoff-switch", "#lab-todooff-switch"];
 
         allStylesArray.forEach((style, index) => {
             const checksMinusCurrentOne = allCheckArray.slice();
@@ -241,7 +248,7 @@ export class Render {
      * @returns {IChartData} - populated chart data object
      * @memberof Render
      */
-    private static buildChartsData(passedTests: number, failedTests: number, pendingTests?: number): IChartData {
+    private static buildChartsData(passedTests: number, failedTests: number, pendingTests?: number, todoTests?: number): IChartData {
         const chartData: IChartData = {
             labels: [],
             backgroundColor: [],
@@ -264,6 +271,12 @@ export class Render {
             chartData.labels.push(Constants.PENDING_LABEL);
             chartData.backgroundColor.push(Constants.PENDING);
             chartData.data.push(pendingTests);
+        }
+
+        if (todoTests > 0) {
+            chartData.labels.push(Constants.TODO_LABEL);
+            chartData.backgroundColor.push(Constants.TODO);
+            chartData.data.push(todoTests);
         }
 
         return chartData;

--- a/src/render/suites/TestSuite.ts
+++ b/src/render/suites/TestSuite.ts
@@ -157,7 +157,7 @@ export class TestSuite {
         accordionCard.classList.add("my-3", "p-3", "bg-white", "rounded", "box-shadow", "card", testStatusClass);
 
         const cardHeader = TestSuite.buildAccordionCardHeader(
-            testResult.testFilePath, testResult.numPassingTests, testResult.numFailingTests, testResult.numPendingTests);
+            testResult.testFilePath, testResult.numPassingTests, testResult.numFailingTests, testResult.numPendingTests, testResult.numTodoTests);
         accordionCard.appendChild(cardHeader);
 
         const cardBody = TestSuite.buildAccordionCardBody(testResult.testFilePath);
@@ -166,7 +166,7 @@ export class TestSuite {
         return accordionCard
     }
 
-    private static buildAccordionCardHeader(testFilePath: string, passCount: number, failCount: number, pendingCount: number) {
+    private static buildAccordionCardHeader(testFilePath: string, passCount: number, failCount: number, pendingCount: number, todoCount: number) {
         const fileName = TestSuite.sanitizeFilePath(testFilePath)
         const cardHeader = document.createElement("div") as HTMLDivElement;
         cardHeader.classList.add("card-header");
@@ -196,6 +196,11 @@ export class TestSuite {
         skipBadge.classList.add("badge", "badge-warning", "border");
         skipBadge.textContent = pendingCount.toString();
         resultCounts.appendChild(skipBadge);
+
+        const todoBadge = document.createElement("span") as HTMLSpanElement;
+        todoBadge.classList.add("badge", "badge-info", "border");
+        todoBadge.textContent = todoCount.toString();
+        resultCounts.appendChild(todoBadge);
 
         btn.appendChild(resultCounts);
         h5.appendChild(btn);

--- a/src/render/tests/Test.ts
+++ b/src/render/tests/Test.ts
@@ -34,6 +34,10 @@ export class Test {
                 color = Constants.PENDING_RAW;
                 testStatusClass = Constants.PENDING_TEST;
                 break;
+            case Constants.TEST_STATUS_TODO:
+                color = Constants.TODO_RAW;
+                testStatusClass = Constants.TODO_TEST;
+                break;
             case Constants.TEST_STATUS_PASS:
                 break;
             default:

--- a/web/jest-stare.css
+++ b/web/jest-stare.css
@@ -114,6 +114,18 @@ code {
     text-align: right;
 }
 
+.todo.off-switch-inner:before {
+    content: "TODO";
+    padding-left: 10px;
+    background-color: #17a2b8; color: #FFFFFF;
+}
+.todo.off-switch-inner:after {
+    content: "TODO";
+    padding-right: 10px;
+    background-color: #EEEEEE; color: #999999;
+    text-align: right;
+}
+
 .summary a {
 
 }
@@ -172,6 +184,10 @@ code {
 
 .summary-test-label.pending {
     color: #ffc107;
+}
+
+.summary-test-label.todo {
+    color: #17a2b8;
 }
 
 .image-snapshot-diff {

--- a/web/template.html
+++ b/web/template.html
@@ -60,6 +60,15 @@
                             </label>
                         </div>
                     </li>
+                    <li class="nav-item">
+                        <div class="onoff-switch mr-sm-2 ml-sm-2">
+                            <input type="checkbox" name="off-switch" class="off-switch-checkbox" id="lab-todooff-switch" checked>
+                            <label class="onoff-switch-label" for="lab-todooff-switch">
+                                <span class="todo off-switch-inner"></span>
+                                <span class="off-switch-switch"></span>
+                            </label>
+                        </div>
+                    </li>
                 </ul>
                 <!-- <form class="form-inline mt-2 mt-md-0">
                     <input class="form-control mr-sm-2" type="text" placeholder="Search" aria-label="Search" disabled>


### PR DESCRIPTION
Adding support for reporting on tests that utilize the [jest.todo](https://jestjs.io/docs/en/api#testtodoname) feature.  With this change:

* TODO tests will be represented in the "tests" donut chart
* TODO tests will have their own summary count in the accordion header
* TODO tests will be called out with their own color in the details section
* Filtering will show/hide TODO tests 

![Screen Shot 2020-09-01 at 12 18 33 PM](https://user-images.githubusercontent.com/11752901/91880006-26c0df80-ec4e-11ea-94f7-429796c7995e.png)
