### PR TITLE
Update README.md => configuration key 'log' was wrongly documented

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Field | Environmental Variable | Default | Description | Example
 `resultJson` |  `JEST_STARE_RESULT_JSON` | `jest-results.json` | indicate the raw JSON results file name | `"resultJson": "data.json"`
 `resultHtml` |  `JEST_STARE_RESULT_HTML` | `index.html` | indicate the main html file name | `"resultHtml": "main.html"`
 `resultHtml` |  `JEST_STARE_RESULT_HTML` | `index.html` | indicate the main html file name | `"resultHtml": "main.html"`
-`log` |  `JEST_STARE_LOG` | `true` | specify whether or not jest-stare should log to the console | `"log": "false"`
+`log` |  `JEST_STARE_LOG` | `true` | specify whether or not jest-stare should log to the console | `"log": false`
 `jestStareConfigJson` |  `JEST_STARE_CONFIG_JSON` |  `undefined` | request to save jest-stare config raw JSON results in the file name | `"jestStareConfigJson": "jest-stare-config.json"`
 `jestGlobalConfigJson` |  `JEST_STARE_GLOBAL_CONFIG_JSON` |  `undefined` | request to save global config results in the file name | `"jestGlobalConfigJson": "global-config.json"`
 `report` |  `JEST_STARE_REPORT` |  `undefined` | boolean, set to false to suppress creating a HTML report (JSON only retained) | `"report": false`


### PR DESCRIPTION
The README.md says the boolean of configuration key 'log' should be passed as a string (ex. "false"), which should be false without any quotemarks as JSON supports boolean values.

The configuration key works correctly if passed as a regular boolean expression in the .JSON