### PR TITLE
Replace node util isNullOrUndefined with own helper due to deprecation

### DIFF
--- a/src/processor/Config.ts
+++ b/src/processor/Config.ts
@@ -1,10 +1,10 @@
-import { isNullOrUndefined } from "util";
 import { Constants } from "./Constants";
 import { IJestStareConfig, PACKAGE_JSON_KEY } from "./doc/IJestStareConfig";
 import { EnvVars } from "./EnvVars";
 import { Logger } from "../utils/Logger";
 import { IProcessParms } from "./doc/IProcessParms";
 import { IO } from "../utils/IO";
+import { isNullOrUndefined } from "../utils/helpers";
 
 /**
  * Configuration for processor
@@ -12,13 +12,16 @@ import { IO } from "../utils/IO";
  * @class Config
  */
 export class Config {
-
     /**
      * Creates an instance of Config.
      * @param {IJestStareConfig} mExplicitConfig - explicit configuration
      * @memberof Config
      */
-    constructor(private mLogger: Logger, private mExplicitConfig: IJestStareConfig, private mProcessParms: IProcessParms) { }
+    constructor(
+        private mLogger: Logger,
+        private mExplicitConfig: IJestStareConfig,
+        private mProcessParms: IProcessParms
+    ) {}
 
     /**
      * Build config from explicit config, package.json, and defaults
@@ -26,13 +29,15 @@ export class Config {
      * @memberof Config
      */
     public buildConfig(): IJestStareConfig {
-
         // get configuration
         const packageJsonConfig = this.getJestStareConfig();
 
         // read environmental variables and merge them with the package.json config (env takes precedence)
         const envVars = new EnvVars();
-        const mergedEnvAndPackageJsonConfig = envVars.resolve(packageJsonConfig, envVars.read());
+        const mergedEnvAndPackageJsonConfig = envVars.resolve(
+            packageJsonConfig,
+            envVars.read()
+        );
 
         // explicit config takes precedence over  env and package.json
         const config = this.mExplicitConfig || mergedEnvAndPackageJsonConfig;
@@ -40,7 +45,10 @@ export class Config {
         // take packagejson options after setting explicit config (concatenate both)
         if (this.mExplicitConfig != null) {
             Object.keys(mergedEnvAndPackageJsonConfig).forEach((key) => {
-                if (isNullOrUndefined(this.mExplicitConfig[key]) && !isNullOrUndefined(mergedEnvAndPackageJsonConfig[key])) {
+                if (
+                    isNullOrUndefined(this.mExplicitConfig[key]) &&
+                    !isNullOrUndefined(mergedEnvAndPackageJsonConfig[key])
+                ) {
                     config[key] = mergedEnvAndPackageJsonConfig[key];
                 }
             });
@@ -54,7 +62,6 @@ export class Config {
             config.resultDir += "/"; // append an extra slash in case the user didn't add one
         }
 
-
         // suppress logging if requested
         // NOTE(Kelosky): must be first, to suppress all logging
         if (!isNullOrUndefined(config.log)) {
@@ -64,7 +71,6 @@ export class Config {
         // record if we were invoked programmatically
         // NOTE(Kelosky): should be second, to record if override config
         if (!isNullOrUndefined(this.mExplicitConfig)) {
-
             // display if not internal invocation
             if (this.mProcessParms && this.mProcessParms.reporter) {
                 // do nothing
@@ -79,7 +85,8 @@ export class Config {
         } else {
             if (config.resultHtml.indexOf(Constants.HTML_EXTENSION) === -1) {
                 // add .html if the user did not specify it
-                config.resultHtml = config.resultHtml + Constants.HTML_EXTENSION;
+                config.resultHtml =
+                    config.resultHtml + Constants.HTML_EXTENSION;
             }
         }
 
@@ -89,7 +96,6 @@ export class Config {
 
         return config;
     }
-
 
     /**
      * Read from the user's package.json, if present
@@ -107,5 +113,4 @@ export class Config {
             return packageJsonObject[PACKAGE_JSON_KEY];
         }
     }
-
 }

--- a/src/processor/Processor.ts
+++ b/src/processor/Processor.ts
@@ -8,11 +8,11 @@ import { Logger } from "../utils/Logger";
 import * as chalk from "chalk";
 import { IThirdPartyDependency } from "./doc/IThirdPartyDependency";
 import { Dependencies } from "./Dependencies";
-import { isNullOrUndefined } from "util";
 import { IProcessParms } from "./doc/IProcessParms";
 import { Config } from "./Config";
 import { ImageSnapshotDifference } from "../render/diff/ImageSnapshotDifference";
 import { AggregatedResult } from "@jest/test-result";
+import { isNullOrUndefined } from "../utils/helpers";
 
 /**
  * Class to post process jest output and summarize information in an html file
@@ -20,7 +20,6 @@ import { AggregatedResult } from "@jest/test-result";
  * @class Processor
  */
 export class Processor {
-
     /**
      * Main exported method to obtain and return summary results
      * @static
@@ -30,8 +29,11 @@ export class Processor {
      * @returns - returns input results object
      * @memberof Processor
      */
-    public static run(results: AggregatedResult, explicitConfig?: IJestStareConfig, parms?: IProcessParms) {
-
+    public static run(
+        results: AggregatedResult,
+        explicitConfig?: IJestStareConfig,
+        parms?: IProcessParms
+    ) {
         return new Processor(results, explicitConfig, parms).generate();
     }
 
@@ -50,8 +52,11 @@ export class Processor {
      * @param {IProcessParms} [mProcessParms] - parms object to control process behavior
      * @memberof Processor
      */
-    constructor(private mResults: AggregatedResult, private mExplicitConfig?: IJestStareConfig, private mProcessParms?: IProcessParms) {
-    }
+    constructor(
+        private mResults: AggregatedResult,
+        private mExplicitConfig?: IJestStareConfig,
+        private mProcessParms?: IProcessParms
+    ) {}
 
     /**
      * Generate a report after constructed
@@ -67,7 +72,11 @@ export class Processor {
             throw new Error(Constants.NO_INPUT);
         }
 
-        const config = new Config(this.logger, this.mExplicitConfig, this.mProcessParms).buildConfig();
+        const config = new Config(
+            this.logger,
+            this.mExplicitConfig,
+            this.mProcessParms
+        ).buildConfig();
 
         // build mustache render substitution values
         substitute.results = this.mResults;
@@ -78,7 +87,11 @@ export class Processor {
         // save in reporter
         if (this.mProcessParms && this.mProcessParms.reporter) {
             this.mProcessParms.reporter.jestStareConfig = config;
-            substitute.globalConfig = JSON.stringify(this.mProcessParms.reporter.mGlobalConfig, null, 2);
+            substitute.globalConfig = JSON.stringify(
+                this.mProcessParms.reporter.mGlobalConfig,
+                null,
+                2
+            );
         }
 
         // generate report
@@ -98,33 +111,47 @@ export class Processor {
      * @param resultDir
      * @param parms
      */
-    private collectImageSnapshots(resultDir: string, results: AggregatedResult) {
+    private collectImageSnapshots(
+        resultDir: string,
+        results: AggregatedResult
+    ) {
         results.testResults.forEach((rootResult) => {
-
             if (rootResult.numFailingTests) {
-
                 rootResult.testResults.forEach((testResult) => {
-
                     testResult.failureMessages.forEach((failureMessage) => {
+                        if (
+                            typeof failureMessage === "string" &&
+                            ImageSnapshotDifference.containsDiff(failureMessage)
+                        ) {
+                            const diffImagePath =
+                                ImageSnapshotDifference.parseDiffImagePath(
+                                    failureMessage
+                                );
+                            const diffImageName =
+                                ImageSnapshotDifference.parseDiffImageName(
+                                    failureMessage
+                                );
 
-                        if (typeof failureMessage === "string" &&
-                         ImageSnapshotDifference.containsDiff(failureMessage)) {
+                            if (IO.existsSync(diffImagePath)) {
+                                IO.mkdirsSync(
+                                    resultDir +
+                                        Constants.IMAGE_SNAPSHOT_DIFF_DIR
+                                );
 
-                         const diffImagePath = ImageSnapshotDifference.parseDiffImagePath(failureMessage);
-                         const diffImageName = ImageSnapshotDifference.parseDiffImageName(failureMessage);
-
-                         if (IO.existsSync(diffImagePath)) {
-                             IO.mkdirsSync(resultDir + Constants.IMAGE_SNAPSHOT_DIFF_DIR);
-
-                             const reportDiffImagePath = resultDir + Constants.IMAGE_SNAPSHOT_DIFF_DIR + diffImageName;
-                             IO.copyFileSync(diffImagePath, reportDiffImagePath);
-                         }
+                                const reportDiffImagePath =
+                                    resultDir +
+                                    Constants.IMAGE_SNAPSHOT_DIFF_DIR +
+                                    diffImageName;
+                                IO.copyFileSync(
+                                    diffImagePath,
+                                    reportDiffImagePath
+                                );
+                            }
                         }
                     });
                 });
             }
         });
-
     }
 
     /**
@@ -135,41 +162,71 @@ export class Processor {
      * @param {ISettings} settings - settings for IO
      * @memberof Processor
      */
-    private generateReport(resultDir: string, substitute: ISubstitute, parms: IProcessParms) {
+    private generateReport(
+        resultDir: string,
+        substitute: ISubstitute,
+        parms: IProcessParms
+    ) {
         // create directory
         IO.mkdirsSync(resultDir);
 
         // create raw json
-        IO.writeFileSync(resultDir + substitute.jestStareConfig.resultJson, substitute.rawResults);
+        IO.writeFileSync(
+            resultDir + substitute.jestStareConfig.resultJson,
+            substitute.rawResults
+        );
 
         // create jest-stare config if requested
         if (substitute.jestStareConfig.jestStareConfigJson) {
-            IO.writeFileSync(resultDir + substitute.jestStareConfig.jestStareConfigJson, substitute.rawJestStareConfig);
+            IO.writeFileSync(
+                resultDir + substitute.jestStareConfig.jestStareConfigJson,
+                substitute.rawJestStareConfig
+            );
         }
 
         // create global config if requested
-        if (substitute.globalConfig && substitute.jestStareConfig.jestGlobalConfigJson) {
-            IO.writeFileSync(resultDir + substitute.jestStareConfig.jestGlobalConfigJson, substitute.globalConfig);
+        if (
+            substitute.globalConfig &&
+            substitute.jestStareConfig.jestGlobalConfigJson
+        ) {
+            IO.writeFileSync(
+                resultDir + substitute.jestStareConfig.jestGlobalConfigJson,
+                substitute.globalConfig
+            );
         }
 
         // exit here for JSON only retain
-        if (substitute.jestStareConfig.report != null && !substitute.jestStareConfig.report) {
+        if (
+            substitute.jestStareConfig.report != null &&
+            !substitute.jestStareConfig.report
+        ) {
             return;
         }
 
         // create base html file
-        IO.writeFileSync(resultDir + substitute.jestStareConfig.resultHtml,
-            mustache.render(this.obtainWebFile(Constants.TEMPLATE_HTML), substitute));
+        IO.writeFileSync(
+            resultDir + substitute.jestStareConfig.resultHtml,
+            mustache.render(
+                this.obtainWebFile(Constants.TEMPLATE_HTML),
+                substitute
+            )
+        );
 
         // create our css
         const cssDir = resultDir + Constants.CSS_DIR;
         IO.mkdirsSync(cssDir);
-        IO.writeFileSync(cssDir + Constants.JEST_STARE_CSS, this.obtainWebFile(Constants.JEST_STARE_CSS));
+        IO.writeFileSync(
+            cssDir + Constants.JEST_STARE_CSS,
+            this.obtainWebFile(Constants.JEST_STARE_CSS)
+        );
 
         // create our js
         const jsDir = resultDir + Constants.JS_DIR;
         IO.mkdirsSync(jsDir);
-        IO.writeFileSync(jsDir + Constants.JEST_STARE_JS, this.obtainJsRenderFile(Constants.JEST_STARE_JS));
+        IO.writeFileSync(
+            jsDir + Constants.JEST_STARE_JS,
+            this.obtainJsRenderFile(Constants.JEST_STARE_JS)
+        );
 
         // add third party dependencies
         Dependencies.THIRD_PARTY_DEPENDENCIES.forEach((dependency) => {
@@ -181,8 +238,18 @@ export class Processor {
 
         // log complete
         let type = " ";
-        type += (parms && parms.reporter) ? Constants.REPORTERS : Constants.TEST_RESULTS_PROCESSOR;
-        this.logger.info(Constants.LOGO + type + Constants.LOG_MESSAGE + resultDir + substitute.jestStareConfig.resultHtml + Constants.SUFFIX);
+        type +=
+            parms && parms.reporter
+                ? Constants.REPORTERS
+                : Constants.TEST_RESULTS_PROCESSOR;
+        this.logger.info(
+            Constants.LOGO +
+                type +
+                Constants.LOG_MESSAGE +
+                resultDir +
+                substitute.jestStareConfig.resultHtml +
+                Constants.SUFFIX
+        );
     }
 
     /**
@@ -195,19 +262,33 @@ export class Processor {
      *                     to forward the data to
      * @memberof Processor
      */
-    private execute(jestTestData: AggregatedResult, processors: string[]): void {
+    private execute(
+        jestTestData: AggregatedResult,
+        processors: string[]
+    ): void {
         for (const processor of processors) {
             if (processor === Constants.NAME) {
-                this.logger.error("Error: In order to avoid infinite loops, " +
-                    "jest-stare cannot be listed as an additional processor. Skipping... ");
+                this.logger.error(
+                    "Error: In order to avoid infinite loops, " +
+                        "jest-stare cannot be listed as an additional processor. Skipping... "
+                );
                 continue;
             }
             try {
                 require(processor)(jestTestData);
-                this.logger.info(Constants.LOGO + " passed results to additional processor " +
-                    chalk.white("\"" + processor + "\"") + Constants.SUFFIX);
+                this.logger.info(
+                    Constants.LOGO +
+                        " passed results to additional processor " +
+                        chalk.white('"' + processor + '"') +
+                        Constants.SUFFIX
+                );
             } catch (e) {
-                this.logger.error("Error executing additional processor: \"" + processor + "\" " + e);
+                this.logger.error(
+                    'Error executing additional processor: "' +
+                        processor +
+                        '" ' +
+                        e
+                );
             }
         }
     }
@@ -219,8 +300,13 @@ export class Processor {
      * @memberof Processor
      */
     private async addThirdParty(dependency: IThirdPartyDependency) {
-        const location = require.resolve(dependency.requireDir + dependency.file);
-        await IO.writeFileSync(dependency.targetDir + dependency.file, IO.readFileSync(location));
+        const location = require.resolve(
+            dependency.requireDir + dependency.file
+        );
+        await IO.writeFileSync(
+            dependency.targetDir + dependency.file,
+            IO.readFileSync(location)
+        );
     }
 
     /**

--- a/src/render/Render.ts
+++ b/src/render/Render.ts
@@ -7,9 +7,9 @@ import { TestSuite } from "./suites/TestSuite";
 import { TestSummary } from "./summary/TestSummary";
 import { IChartData } from "./doc/IChartData";
 import { IJestStareConfig } from "../processor/doc/IJestStareConfig";
-import { isNullOrUndefined } from "util";
 import { AggregatedResult } from "@jest/test-result";
 import { Config } from "@jest/types";
+import { isNullOrUndefined } from "../utils/helpers";
 
 /**
  * Adjust DOM to display JSON data
@@ -17,7 +17,6 @@ import { Config } from "@jest/types";
  * @class Render
  */
 export class Render {
-
     /**
      * Wait for DOM load then show
      * @static
@@ -26,14 +25,26 @@ export class Render {
      */
     public static init() {
         document.addEventListener("DOMContentLoaded", () => {
-            const config: IJestStareConfig = JSON.parse($("#test-config").text());
-            const results: AggregatedResult = JSON.parse($("#test-results").text());
+            const config: IJestStareConfig = JSON.parse(
+                $("#test-config").text()
+            );
+            const results: AggregatedResult = JSON.parse(
+                $("#test-results").text()
+            );
 
             try {
-                const globalConfig: Config.InitialOptions = JSON.parse($("#test-global-config").text());
-                const regex = new RegExp(Render.escapeRegExp(globalConfig.rootDir), "g");
+                const globalConfig: Config.InitialOptions = JSON.parse(
+                    $("#test-global-config").text()
+                );
+                const regex = new RegExp(
+                    Render.escapeRegExp(globalConfig.rootDir),
+                    "g"
+                );
                 results.testResults.forEach((testResult) => {
-                    testResult.testFilePath = testResult.testFilePath.replace(regex, "");
+                    testResult.testFilePath = testResult.testFilePath.replace(
+                        regex,
+                        ""
+                    );
                 });
             } catch (e) {
                 // do nothing
@@ -64,7 +75,6 @@ export class Render {
      * @memberof Render
      */
     private static show(results: AggregatedResult, config: IJestStareConfig) {
-
         const labels = [Constants.PASSED_LABEL, Constants.FAILED_LABEL];
         const backgroundColor = [Constants.PASS, Constants.FAIL];
 
@@ -76,17 +86,38 @@ export class Render {
 
         if (!config.disableCharts) {
             // build suites chart
-            const suitesData = Render.buildChartsData(results.numPassedTestSuites, results.numFailedTestSuites, results.numPendingTestSuites);
-            Doughnut.createChart($("#test-suites-canvas") as JQuery<HTMLCanvasElement>, suitesData);
+            const suitesData = Render.buildChartsData(
+                results.numPassedTestSuites,
+                results.numFailedTestSuites,
+                results.numPendingTestSuites
+            );
+            Doughnut.createChart(
+                $("#test-suites-canvas") as JQuery<HTMLCanvasElement>,
+                suitesData
+            );
 
             // build tests chart
-            const testsChart = Render.buildChartsData(results.numPassedTests, results.numFailedTests, results.numPendingTests, results.numTodoTests);
-            Doughnut.createChart($("#tests-canvas") as JQuery<HTMLCanvasElement>, testsChart);
+            const testsChart = Render.buildChartsData(
+                results.numPassedTests,
+                results.numFailedTests,
+                results.numPendingTests,
+                results.numTodoTests
+            );
+            Doughnut.createChart(
+                $("#tests-canvas") as JQuery<HTMLCanvasElement>,
+                testsChart
+            );
 
             // base snapshot data
-            let snapshotChart = Render.buildChartsData(results.snapshot.matched, results.snapshot.unmatched);
+            let snapshotChart = Render.buildChartsData(
+                results.snapshot.matched,
+                results.snapshot.unmatched
+            );
             snapshotChart = Render.addSnapshotChartData(results, snapshotChart);
-            Doughnut.createChart($("#snapshots-canvas") as JQuery<HTMLCanvasElement>, snapshotChart);
+            Doughnut.createChart(
+                $("#snapshots-canvas") as JQuery<HTMLCanvasElement>,
+                snapshotChart
+            );
         }
 
         // update status area
@@ -141,18 +172,37 @@ export class Render {
         }
 
         if (config.hideFailing && config.hidePassing && config.hidePending) {
-            $(`.${Constants.FAILED_TEST}\\.${Constants.PASSED_TEST}\\.${Constants.PENDING_TEST}`).hide();
+            $(
+                `.${Constants.FAILED_TEST}\\.${Constants.PASSED_TEST}\\.${Constants.PENDING_TEST}`
+            ).hide();
         }
 
-
         const allCheckArray = new Array<JQuery<HTMLInputElement>>();
-        allCheckArray.push($("#lab-passoff-switch") as JQuery<HTMLInputElement>);
-        allCheckArray.push($("#lab-failoff-switch") as JQuery<HTMLInputElement>);
-        allCheckArray.push($("#lab-pendingoff-switch") as JQuery<HTMLInputElement>);
-        allCheckArray.push($("#lab-todooff-switch") as JQuery<HTMLInputElement>);
+        allCheckArray.push(
+            $("#lab-passoff-switch") as JQuery<HTMLInputElement>
+        );
+        allCheckArray.push(
+            $("#lab-failoff-switch") as JQuery<HTMLInputElement>
+        );
+        allCheckArray.push(
+            $("#lab-pendingoff-switch") as JQuery<HTMLInputElement>
+        );
+        allCheckArray.push(
+            $("#lab-todooff-switch") as JQuery<HTMLInputElement>
+        );
 
-        const allStylesArray = [Constants.PASSED_TEST, Constants.FAILED_TEST, Constants.PENDING_TEST, Constants.TODO_TEST];
-        const allSwitchArray = ["#lab-passoff-switch", "#lab-failoff-switch", "#lab-pendingoff-switch", "#lab-todooff-switch"];
+        const allStylesArray = [
+            Constants.PASSED_TEST,
+            Constants.FAILED_TEST,
+            Constants.PENDING_TEST,
+            Constants.TODO_TEST,
+        ];
+        const allSwitchArray = [
+            "#lab-passoff-switch",
+            "#lab-failoff-switch",
+            "#lab-pendingoff-switch",
+            "#lab-todooff-switch",
+        ];
 
         allStylesArray.forEach((style, index) => {
             const checksMinusCurrentOne = allCheckArray.slice();
@@ -180,23 +230,34 @@ export class Render {
     private static updateStatusArea(results: AggregatedResult) {
         Status.setResultsClass(
             $("#test-suites-results") as JQuery<HTMLParagraphElement>,
-            results.numPassedTestSuites, results.numTotalTestSuites - results.numPassedTestSuites - results.numPendingTestSuites);
+            results.numPassedTestSuites,
+            results.numTotalTestSuites -
+                results.numPassedTestSuites -
+                results.numPendingTestSuites
+        );
         Status.setResultsClass(
             $("#tests-results") as JQuery<HTMLParagraphElement>,
-            results.numPassedTests, results.numTotalTests - results.numPassedTests - results.numPendingTests);
+            results.numPassedTests,
+            results.numTotalTests -
+                results.numPassedTests -
+                results.numPendingTests
+        );
         Status.setResultsClass(
             $("#snapshots-results") as JQuery<HTMLParagraphElement>,
-            results.snapshot.matched, results.snapshot.unmatched);
+            results.snapshot.matched,
+            results.snapshot.unmatched
+        );
 
-        if (results.snapshot.added === 0 &&
+        if (
+            results.snapshot.added === 0 &&
             results.snapshot.matched === 0 &&
             results.snapshot.unchecked === 0 &&
             results.snapshot.unmatched === 0 &&
-            results.snapshot.updated === 0) {
+            results.snapshot.updated === 0
+        ) {
             $("#snapshots-group").hide();
         }
     }
-
 
     /**
      * Set report title if presented in jest-stare config
@@ -206,7 +267,9 @@ export class Render {
      * @memberof Render
      */
     private static setReportTitle(config: IJestStareConfig) {
-        const tabTitle = !isNullOrUndefined(config.reportTitle) ? config.reportTitle : "jest-stare!";
+        const tabTitle = !isNullOrUndefined(config.reportTitle)
+            ? config.reportTitle
+            : "jest-stare!";
         document.title = tabTitle;
     }
 
@@ -218,7 +281,9 @@ export class Render {
      * @memberof Render
      */
     private static setReportHeadline(config: IJestStareConfig) {
-        const brandTitle =  !isNullOrUndefined(config.reportHeadline) ? config.reportHeadline : "jest-stare";
+        const brandTitle = !isNullOrUndefined(config.reportHeadline)
+            ? config.reportHeadline
+            : "jest-stare";
         const a = $("#navbar-title");
         a.text(brandTitle);
     }
@@ -248,7 +313,12 @@ export class Render {
      * @returns {IChartData} - populated chart data object
      * @memberof Render
      */
-    private static buildChartsData(passedTests: number, failedTests: number, pendingTests?: number, todoTests?: number): IChartData {
+    private static buildChartsData(
+        passedTests: number,
+        failedTests: number,
+        pendingTests?: number,
+        todoTests?: number
+    ): IChartData {
         const chartData: IChartData = {
             labels: [],
             backgroundColor: [],
@@ -291,8 +361,10 @@ export class Render {
      * @returns {IChartData} - completed snapshot chart
      * @memberof Render
      */
-    private static addSnapshotChartData(results: AggregatedResult, snapshotChart: IChartData): IChartData {
-
+    private static addSnapshotChartData(
+        results: AggregatedResult,
+        snapshotChart: IChartData
+    ): IChartData {
         // add info about added snapshots if present
         if (results.snapshot.filesAdded > 0) {
             snapshotChart.labels.push(Constants.ADDED_LABEL);
@@ -306,12 +378,20 @@ export class Render {
         // if didUpdate = true, the file was removed, otherwise its just a warning
         if (results.snapshot.unchecked > 0) {
             if (results.snapshot.didUpdate) {
-                snapshotChart.labels.push(Constants.UPDATED_SNAPSHOT_TEST_LABEL);
-                snapshotChart.backgroundColor.push(Constants.UPDATED_SNAPSHOT_TEST);
+                snapshotChart.labels.push(
+                    Constants.UPDATED_SNAPSHOT_TEST_LABEL
+                );
+                snapshotChart.backgroundColor.push(
+                    Constants.UPDATED_SNAPSHOT_TEST
+                );
                 snapshotChart.data.push(results.snapshot.unchecked);
             } else {
-                snapshotChart.labels.push(Constants.OBSOLETE_SNAPSHOT_TEST_LABEL);
-                snapshotChart.backgroundColor.push(Constants.OBSOLETE_SNAPSHOT_TEST);
+                snapshotChart.labels.push(
+                    Constants.OBSOLETE_SNAPSHOT_TEST_LABEL
+                );
+                snapshotChart.backgroundColor.push(
+                    Constants.OBSOLETE_SNAPSHOT_TEST
+                );
                 snapshotChart.data.push(results.snapshot.unchecked);
             }
         }
@@ -328,19 +408,25 @@ export class Render {
         // have a snapshot file which contains just a comment and not snapshots
         // if didUpdate = true, the file was removed, otherwise its just a warning
         if (results.snapshot.filesRemoved > 0) {
-
             if (results.snapshot.didUpdate) {
-                snapshotChart.labels.push(Constants.REMOVED_OBSOLETE_SNAPSHOT_FILE_LABEL);
-                snapshotChart.backgroundColor.push(Constants.REMOVED_OBSOLETE_SNAPSHOT_FILE);
+                snapshotChart.labels.push(
+                    Constants.REMOVED_OBSOLETE_SNAPSHOT_FILE_LABEL
+                );
+                snapshotChart.backgroundColor.push(
+                    Constants.REMOVED_OBSOLETE_SNAPSHOT_FILE
+                );
                 snapshotChart.data.push(results.snapshot.filesRemoved);
             } else {
-                snapshotChart.labels.push(Constants.OBSOLETE_SNAPSHOT_FILE_LABEL);
-                snapshotChart.backgroundColor.push(Constants.OBSOLETE_SNAPSHOT_FILE);
+                snapshotChart.labels.push(
+                    Constants.OBSOLETE_SNAPSHOT_FILE_LABEL
+                );
+                snapshotChart.backgroundColor.push(
+                    Constants.OBSOLETE_SNAPSHOT_FILE
+                );
                 snapshotChart.data.push(results.snapshot.filesRemoved);
             }
         }
 
         return snapshotChart;
     }
-
 }

--- a/src/render/navigation/Switch.ts
+++ b/src/render/navigation/Switch.ts
@@ -1,4 +1,4 @@
-import { isNullOrUndefined } from "util";
+import { isNullOrUndefined } from "../../utils/helpers";
 
 /**
  * Associates a switch (checkbox) to a class to show if checked or hide if unchecked)
@@ -6,7 +6,6 @@ import { isNullOrUndefined } from "util";
  * @class Switch
  */
 export class Switch {
-
     /**
      * Ancestor title join character (We need to escape the "." in order to jquery to get the class correctly)
      * @static
@@ -39,9 +38,19 @@ export class Switch {
      * @memberof Switch
      */
     constructor(
-        checkBox: JQuery<HTMLInputElement>, divClass: JQuery<HTMLDivElement>, divClassName?: string,
-        addtnlCheckBoxArray?: JQuery<HTMLInputElement>[], addtnlClassNameArray?: string[]) {
-            this.activateFilters(checkBox, divClass, divClassName, addtnlCheckBoxArray, addtnlClassNameArray);
+        checkBox: JQuery<HTMLInputElement>,
+        divClass: JQuery<HTMLDivElement>,
+        divClassName?: string,
+        addtnlCheckBoxArray?: JQuery<HTMLInputElement>[],
+        addtnlClassNameArray?: string[]
+    ) {
+        this.activateFilters(
+            checkBox,
+            divClass,
+            divClassName,
+            addtnlCheckBoxArray,
+            addtnlClassNameArray
+        );
     }
 
     /**
@@ -55,45 +64,75 @@ export class Switch {
      * @memberof Switch
      */
     private activateFilters(
-        checkBox: JQuery<HTMLInputElement>, divClass: JQuery<HTMLDivElement>, divClassName?: string,
-        addtnlCheckBoxArray?: JQuery<HTMLInputElement>[], addtnlClassNameArray?: string[]) {
-            checkBox.change(() => {
-                if (checkBox.is(":checked")) {
-                    divClass.show();
-                    if (!isNullOrUndefined(addtnlCheckBoxArray)) {
-                        addtnlCheckBoxArray.forEach((addtnlCheckBox, index) => {
-                            const mixedDualClass = Switch.mixStatus(addtnlClassNameArray[index], divClassName);
-                            const mixedClassDiv = $("." + mixedDualClass) as JQuery<HTMLDivElement>;
-                            mixedClassDiv.show();
-                        });
+        checkBox: JQuery<HTMLInputElement>,
+        divClass: JQuery<HTMLDivElement>,
+        divClassName?: string,
+        addtnlCheckBoxArray?: JQuery<HTMLInputElement>[],
+        addtnlClassNameArray?: string[]
+    ) {
+        checkBox.change(() => {
+            if (checkBox.is(":checked")) {
+                divClass.show();
+                if (!isNullOrUndefined(addtnlCheckBoxArray)) {
+                    addtnlCheckBoxArray.forEach((addtnlCheckBox, index) => {
+                        const mixedDualClass = Switch.mixStatus(
+                            addtnlClassNameArray[index],
+                            divClassName
+                        );
+                        const mixedClassDiv = $(
+                            "." + mixedDualClass
+                        ) as JQuery<HTMLDivElement>;
+                        mixedClassDiv.show();
+                    });
 
-                        const mixedClass = Switch.mixStatus(addtnlClassNameArray[0], divClassName);
-                        const allMixedClass = Switch.mixStatus(addtnlClassNameArray[1], mixedClass);
-                        const allMixedClassDiv =  $("." + allMixedClass) as JQuery<HTMLDivElement>;
-                        allMixedClassDiv.show();
-                    }
-                } else {
-                    divClass.hide();
-                    if (!isNullOrUndefined(addtnlCheckBoxArray)) {
-                        let allUnchecked = true;
-                        addtnlCheckBoxArray.forEach((addtnlCheckBox, index) => {
-                            if (!addtnlCheckBox.is(":checked")) {
-                                const mixedClass = Switch.mixStatus(addtnlClassNameArray[index], divClassName);
-                                const mixedClassDiv = $("." + mixedClass) as JQuery<HTMLDivElement>;
-                                mixedClassDiv.hide();
-                            } else {
-                                allUnchecked = false;
-                            }
-                        });
-
-                        if (allUnchecked) {
-                            const mixedClass = Switch.mixStatus(addtnlClassNameArray[0], divClassName);
-                            const allMixedClass = Switch.mixStatus(addtnlClassNameArray[1], mixedClass);
-                            const allMixedClassDiv =  $("." + allMixedClass) as JQuery<HTMLDivElement>;
-                            allMixedClassDiv.hide();
+                    const mixedClass = Switch.mixStatus(
+                        addtnlClassNameArray[0],
+                        divClassName
+                    );
+                    const allMixedClass = Switch.mixStatus(
+                        addtnlClassNameArray[1],
+                        mixedClass
+                    );
+                    const allMixedClassDiv = $(
+                        "." + allMixedClass
+                    ) as JQuery<HTMLDivElement>;
+                    allMixedClassDiv.show();
+                }
+            } else {
+                divClass.hide();
+                if (!isNullOrUndefined(addtnlCheckBoxArray)) {
+                    let allUnchecked = true;
+                    addtnlCheckBoxArray.forEach((addtnlCheckBox, index) => {
+                        if (!addtnlCheckBox.is(":checked")) {
+                            const mixedClass = Switch.mixStatus(
+                                addtnlClassNameArray[index],
+                                divClassName
+                            );
+                            const mixedClassDiv = $(
+                                "." + mixedClass
+                            ) as JQuery<HTMLDivElement>;
+                            mixedClassDiv.hide();
+                        } else {
+                            allUnchecked = false;
                         }
+                    });
+
+                    if (allUnchecked) {
+                        const mixedClass = Switch.mixStatus(
+                            addtnlClassNameArray[0],
+                            divClassName
+                        );
+                        const allMixedClass = Switch.mixStatus(
+                            addtnlClassNameArray[1],
+                            mixedClass
+                        );
+                        const allMixedClassDiv = $(
+                            "." + allMixedClass
+                        ) as JQuery<HTMLDivElement>;
+                        allMixedClassDiv.hide();
                     }
                 }
-            });
+            }
+        });
     }
 }

--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -1,6 +1,7 @@
-import { format, isNullOrUndefined } from "util";
+import { format } from "util";
 import * as moment from "moment";
 import * as chalk from "chalk";
+import { isNullOrUndefined } from "./helpers";
 
 /**
  * Class to contain writing log messages
@@ -8,13 +9,19 @@ import * as chalk from "chalk";
  * @class Logger
  */
 export class Logger {
-
     /**
      * Supported levels of logging
      * @static
      * @memberof Logger
      */
-    public static readonly LEVELS = ["trace", "debug", "info", "warn", "error", "fatal"];
+    public static readonly LEVELS = [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error",
+        "fatal",
+    ];
 
     /**
      * Default log level
@@ -119,7 +126,10 @@ export class Logger {
      * @memberof Logger
      */
     public isTraceEnabled(): boolean {
-        return Logger.LEVELS.indexOf("trace") >= Logger.LEVELS.indexOf(this.level) ? this.on : false;
+        return Logger.LEVELS.indexOf("trace") >=
+            Logger.LEVELS.indexOf(this.level)
+            ? this.on
+            : false;
     }
 
     /**
@@ -128,7 +138,10 @@ export class Logger {
      * @memberof Logger
      */
     public isDebugEnabled(): boolean {
-        return Logger.LEVELS.indexOf("debug") >= Logger.LEVELS.indexOf(this.level) ? this.on : false;
+        return Logger.LEVELS.indexOf("debug") >=
+            Logger.LEVELS.indexOf(this.level)
+            ? this.on
+            : false;
     }
 
     /**
@@ -137,7 +150,10 @@ export class Logger {
      * @memberof Logger
      */
     public isInfoEnabled(): boolean {
-        return Logger.LEVELS.indexOf("info") >= Logger.LEVELS.indexOf(this.level) ? this.on : false;
+        return Logger.LEVELS.indexOf("info") >=
+            Logger.LEVELS.indexOf(this.level)
+            ? this.on
+            : false;
     }
 
     /**
@@ -146,7 +162,10 @@ export class Logger {
      * @memberof Logger
      */
     public isWarnEnabled(): boolean {
-        return Logger.LEVELS.indexOf("warn") >= Logger.LEVELS.indexOf(this.level) ? this.on : false;
+        return Logger.LEVELS.indexOf("warn") >=
+            Logger.LEVELS.indexOf(this.level)
+            ? this.on
+            : false;
     }
 
     /**
@@ -155,7 +174,10 @@ export class Logger {
      * @memberof Logger
      */
     public isErrorEnabled(): boolean {
-        return Logger.LEVELS.indexOf("error") >= Logger.LEVELS.indexOf(this.level) ? this.on : false;
+        return Logger.LEVELS.indexOf("error") >=
+            Logger.LEVELS.indexOf(this.level)
+            ? this.on
+            : false;
     }
 
     /**
@@ -164,7 +186,10 @@ export class Logger {
      * @memberof Logger
      */
     public isFatalEnabled(): boolean {
-        return Logger.LEVELS.indexOf("fatal") >= Logger.LEVELS.indexOf(this.level) ? this.on : false;
+        return Logger.LEVELS.indexOf("fatal") >=
+            Logger.LEVELS.indexOf(this.level)
+            ? this.on
+            : false;
     }
 
     /**
@@ -358,7 +383,16 @@ export class Logger {
      * @memberof Logger
      */
     private buildPrefix(type: string) {
-        return "[" + moment().format("YYYY/MM/DD HH:MM:SS") + "]" + " " + "[" + type + "]" + " ";
+        return (
+            "[" +
+            moment().format("YYYY/MM/DD HH:MM:SS") +
+            "]" +
+            " " +
+            "[" +
+            type +
+            "]" +
+            " "
+        );
     }
 
     /**

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,0 +1,5 @@
+export function isNullOrUndefined<T>(
+    value: T | undefined | null
+): value is null | undefined {
+    return value === undefined || value === null;
+}


### PR DESCRIPTION
When using `jest-stare`, the following warning always appears:

> (node:33071) [DEP0051] DeprecationWarning: The `util.isNullOrUndefined` API is deprecated. Please use `arg === null || arg === undefined` instead.

This PR removes the deprecated function and instead provides the same functionality as a helper.